### PR TITLE
Safe abstraction interner wrapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,19 @@ rust:
   - nightly
 
 matrix:
-  allow_failures:
+  include:
     - rust: nightly
+      env: FEATURES="--all-features"
 
 env:
   global:
   - RUSTFLAGS="-C link-dead-code"
+  matrix:
+  - FEATURES=""
+  - FEATURES="--no-default-features"
+
+script:
+  - cargo test $FEATURES
 
 addons:
   apt:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,24 @@ categories = ["data-structures"]
 [dependencies]
 serde = { version = "1.0.0", optional = true }
 
+# should be a dev-dependency but optional dev dependencies aren't allowed rust-lang/cargo#1596
+compiletest_rs = { version = "0.3.6", optional = true } # required to test compile failures
+
 [dev-dependencies]
 fnv = "1.0.0" # required for some bench tests
 serde_json = "1.0.0" # required for testing the serde imlementation
-compiletest_rs = "0.3.6" # required to test `PooledStr` cannot not outlive its `StringPool`
 
 [features]
 default       = ["serde_support"]
 bench         = []
 serde_support = ["serde"]
+compiletest   = ["compiletest_rs"]
 
 [badges]
 travis-ci = { repository = "Robbepop/string-interner" }
 appveyor = { repository = "Robbepop/string-interner", branch = "master", service = "github" }
+
+[[test]]
+name = "compiletests"
+path = "tests/compiletests.rs"
+required-features = ["compiletest"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["data-structures"]
 serde = { version = "1.0.0", optional = true }
 
 # should be a dev-dependency but optional dev dependencies aren't allowed rust-lang/cargo#1596
-compiletest_rs = { version = "0.3.6", optional = true } # required to test compile failures
+#compiletest_rs = { version = "0.3.6", optional = true } # required to test compile failures
 
 [dev-dependencies]
 fnv = "1.0.0" # required for some bench tests
@@ -26,7 +26,7 @@ serde_json = "1.0.0" # required for testing the serde imlementation
 default       = ["serde_support"]
 bench         = []
 serde_support = ["serde"]
-compiletest   = ["compiletest_rs"]
+#compiletest   = ["compiletest_rs"]
 
 [badges]
 travis-ci = { repository = "Robbepop/string-interner" }
@@ -35,4 +35,4 @@ appveyor = { repository = "Robbepop/string-interner", branch = "master", service
 [[test]]
 name = "compiletests"
 path = "tests/compiletests.rs"
-required-features = ["compiletest"]
+#required-features = ["compiletest"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["data-structures"]
 
 [dependencies]
 serde = { version = "1.0.0", optional = true }
+serde_derive = { version = "1.0.0", optional = true }
 
 [dev-dependencies]
 fnv = "1.0.0" # required for some bench tests
@@ -22,7 +23,7 @@ serde_json = "1.0.0" # required for testing the serde imlementation
 [features]
 default       = ["serde_support"]
 bench         = []
-serde_support = ["serde"]
+serde_support = ["serde", "serde_derive"]
 
 [badges]
 travis-ci = { repository = "Robbepop/string-interner" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,16 @@ categories = ["data-structures"]
 
 [dependencies]
 serde = { version = "1.0.0", optional = true }
-serde_derive = { version = "1.0.0", optional = true }
 
 [dev-dependencies]
 fnv = "1.0.0" # required for some bench tests
 serde_json = "1.0.0" # required for testing the serde imlementation
+compiletest_rs = "0.3.6" # required to test `PooledStr` cannot not outlive its `StringPool`
 
 [features]
 default       = ["serde_support"]
 bench         = []
-serde_support = ["serde", "serde_derive"]
+serde_support = ["serde"]
 
 [badges]
 travis-ci = { repository = "Robbepop/string-interner" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ mod benches;
 #[cfg(feature = "serde_support")]
 mod serde_impl;
 
+/// A safe wrapped interface where the symbols transparently deref to `&str`
 pub mod wrapped;
 
 use std::vec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,13 +4,13 @@
 
 //! A string interning data structure that was designed for minimal memory-overhead
 //! and fast access to the underlying interned string contents.
-//! 
+//!
 //! Uses a similar interface as the string interner of the rust compiler.
-//! 
+//!
 //! Provides support to use all primitive types as symbols
-//! 
+//!
 //! Example usage:
-//! 
+//!
 //! ```
 //! 	use string_interner::DefaultStringInterner;
 //! 	let mut interner = DefaultStringInterner::default();
@@ -40,6 +40,9 @@ extern crate fnv;
 
 #[cfg(feature = "serde_support")]
 extern crate serde;
+#[macro_use]
+#[cfg(feature = "serde_support")]
+extern crate serde_derive;
 
 #[cfg(all(feature = "serde_support", test))]
 extern crate serde_json;
@@ -65,20 +68,20 @@ use std::collections::HashMap;
 use std::collections::hash_map::RandomState;
 
 /// Represents indices into the `StringInterner`.
-/// 
+///
 /// Values of this type shall be lightweight as the whole purpose
 /// of interning values is to be able to store them efficiently in memory.
-/// 
+///
 /// This trait allows definitions of custom `Symbol`s besides
 /// the already supported unsigned integer primitives.
 pub trait Symbol: Copy + Ord + Eq {
 	/// Creates a symbol explicitely from a usize primitive type.
-	/// 
+	///
 	/// Defaults to simply using the standard From<usize> trait.
 	fn from_usize(val: usize) -> Self;
 
 	/// Creates a usize explicitely from this symbol.
-	/// 
+	///
 	/// Defaults to simply using the standard Into<usize> trait.
 	fn to_usize(self) -> usize;
 }
@@ -97,7 +100,7 @@ struct InternalStrRef(*const str);
 
 impl InternalStrRef {
 	/// Creates an InternalStrRef from a str.
-	/// 
+	///
 	/// This just wraps the str internally.
 	fn from_str(val: &str) -> Self {
 		InternalStrRef(val as *const str)
@@ -105,12 +108,12 @@ impl InternalStrRef {
 
 
 	/// Reinterprets this InternalStrRef as a str.
-	/// 
+	///
 	/// This is "safe" as long as this InternalStrRef only
 	/// refers to strs that outlive this instance or
 	/// the instance that owns this InternalStrRef.
 	/// This should hold true for `StringInterner`.
-	/// 
+	///
 	/// Does not allocate memory!
 	fn as_str(&self) -> &str {
 		unsafe{ &*self.0 }
@@ -145,9 +148,9 @@ pub type DefaultStringInterner = StringInterner<usize>;
 /// the interner and indices.
 /// The main purpose is to store every unique String only once and
 /// make it possible to reference it via lightweight indices.
-/// 
+///
 /// Compilers often use this for implementing a symbol table.
-/// 
+///
 /// The main goal of this `StringInterner` is to store String
 /// with as low memory overhead as possible.
 #[derive(Debug, Clone, Eq)]
@@ -177,10 +180,10 @@ impl Default for StringInterner<usize, RandomState> {
 
 // About `Send` and `Sync` impls for `StringInterner`
 // --------------------------------------------------
-// 
+//
 // tl;dr: Automation of Send+Sync impl was prevented by `InternalStrRef`
 // being an unsafe abstraction and thus prevented Send+Sync default derivation.
-// 
+//
 // These implementations are safe due to the following reasons:
 //  - `InternalStrRef` cannot be used outside `StringInterner`.
 //  - Strings stored in `StringInterner` are not mutable.
@@ -235,9 +238,9 @@ impl<Sym, H> StringInterner<Sym, H>
 	}
 
 	/// Interns the given value.
-	/// 
+	///
 	/// Returns a symbol to access it within this interner.
-	/// 
+	///
 	/// This either copies the contents of the string (e.g. for str)
 	/// or moves them into this interner (e.g. for String).
 	#[inline]
@@ -251,7 +254,7 @@ impl<Sym, H> StringInterner<Sym, H>
 	}
 
 	/// Interns the given value and ignores collissions.
-	/// 
+	///
 	/// Returns a symbol to access it within this interner.
 	fn intern<T>(&mut self, new_val: T) -> Sym
 		where T: Into<String> + AsRef<str>
@@ -320,7 +323,7 @@ impl<Sym, H> StringInterner<Sym, H>
 	}
 
 	/// Removes all interned Strings from this interner.
-	/// 
+	///
 	/// This invalides all `Symbol` entities instantiated by it so far.
 	#[inline]
 	pub fn clear(&mut self) {
@@ -344,7 +347,7 @@ pub struct Iter<'a, Sym> {
 impl<'a, Sym> Iter<'a, Sym>
 	where Sym: Symbol + 'a
 {
-	/// Creates a new iterator for the given StringIterator over pairs of 
+	/// Creates a new iterator for the given StringIterator over pairs of
 	/// symbols and their associated interned string.
 	#[inline]
 	fn new<H>(interner: &'a StringInterner<Sym, H>) -> Self
@@ -421,7 +424,7 @@ impl<Sym, H> iter::IntoIterator for StringInterner<Sym, H>
 	}
 }
 
-/// Iterator over the pairs of symbols and associated interned string when 
+/// Iterator over the pairs of symbols and associated interned string when
 /// morphing a `StringInterner` into an iterator.
 pub struct IntoIter<Sym>
 	where Sym: Symbol

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@ mod benches;
 #[cfg(feature = "serde_support")]
 mod serde_impl;
 
+pub mod wrapped;
+
 use std::vec;
 use std::slice;
 use std::iter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,6 @@ extern crate fnv;
 
 #[cfg(feature = "serde_support")]
 extern crate serde;
-#[macro_use]
-#[cfg(feature = "serde_support")]
-extern crate serde_derive;
 
 #[cfg(all(feature = "serde_support", test))]
 extern crate serde_json;

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -1,12 +1,16 @@
 #![allow(missing_docs)]
 
-use {StringInterner, Symbol, Iter, Values};
+use {Iter, StringInterner, Symbol, Values};
 use std::collections::hash_map::RandomState;
 use std::hash::BuildHasher;
 use std::ops::Deref;
 
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct PooledStr<'pool, Sym: Symbol + 'pool = usize, H: BuildHasher + 'pool = RandomState> {
+	#[cfg_attr(feature = "serde_support",
+	           serde(bound(serialize = "&'pool StringPool<Sym, H>: ::serde::Serialize",
+	                       deserialize = "&'pool StringPool<Sym, H>: ::serde::Deserialize<'de>")))]
 	pool: &'pool StringPool<Sym, H>,
 	sym: Sym,
 }
@@ -37,9 +41,21 @@ impl<'pool, Sym: Symbol + 'pool, H: BuildHasher + 'pool> PooledStr<'pool, Sym, H
 	}
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct StringPool<Sym: Symbol = usize, H: BuildHasher = RandomState> {
+	#[cfg_attr(feature = "serde_support",
+	           serde(bound(serialize = "StringInterner<Sym, H>: ::serde::Serialize",
+	                       deserialize = "StringInterner<Sym, H>: ::serde::Deserialize<'de>")))]
 	interner: StringInterner<Sym, H>,
+}
+
+impl<Sym: Symbol> Default for StringPool<Sym> {
+	fn default() -> Self {
+		StringPool {
+			interner: Default::default(),
+		}
+	}
 }
 
 impl<Sym: Symbol> StringPool<Sym> {

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -1,0 +1,112 @@
+#![allow(missing_docs)]
+
+use {StringInterner, Symbol, Iter, Values};
+use std::collections::hash_map::RandomState;
+use std::hash::BuildHasher;
+use std::ops::Deref;
+
+#[derive(Copy, Clone, Debug)]
+pub struct PooledStr<'pool, Sym: Symbol + 'pool = usize, H: BuildHasher + 'pool = RandomState> {
+	pool: &'pool StringPool<Sym, H>,
+	sym: Sym,
+}
+
+impl<'pool, Sym: Symbol + 'pool, H: BuildHasher + 'pool> Eq for PooledStr<'pool, Sym, H> {}
+impl<'pool, Sym: Symbol + 'pool, H: BuildHasher + 'pool> PartialEq<Self> for PooledStr<'pool, Sym, H> {
+	fn eq(&self, other: &Self) -> bool {
+		self.sym == other.sym && ::std::ptr::eq(self.pool, other.pool)
+	}
+}
+
+impl<'pool, Sym: Symbol + 'pool, H: BuildHasher + 'pool> Deref for PooledStr<'pool, Sym, H> {
+	type Target = str;
+	fn deref(&self) -> &str {
+		// in the future, maybe use resolve_unchecked
+		PooledStr::resolve(self)
+	}
+}
+
+impl<'pool, Sym: Symbol + 'pool, H: BuildHasher + 'pool> PooledStr<'pool, Sym, H> {
+	pub fn resolve(this: &Self) -> &str {
+		this.pool.interner.resolve(this.sym)
+			.expect("PooledStr exists without entry in StringPool")
+	}
+
+	pub unsafe fn resolve_unchecked(this: &Self) -> &str {
+		this.pool.interner.resolve_unchecked(this.sym)
+	}
+}
+
+#[derive(Debug)]
+pub struct StringPool<Sym: Symbol = usize, H: BuildHasher = RandomState> {
+	interner: StringInterner<Sym, H>,
+}
+
+impl<Sym: Symbol> StringPool<Sym> {
+	pub fn new() -> Self {
+		StringPool {
+			interner: StringInterner::new(),
+		}
+	}
+
+	pub fn with_capacity(cap: usize) -> Self {
+		StringPool {
+			interner: StringInterner::with_capacity(cap),
+		}
+	}
+}
+
+impl<Sym: Symbol, H: BuildHasher> StringPool<Sym, H> {
+	pub fn with_hasher(hasher: H) -> Self {
+		StringPool {
+			interner: StringInterner::with_hasher(hasher),
+		}
+	}
+
+	pub fn with_capacity_and_hasher(cap: usize, hasher: H) -> Self {
+		StringPool {
+			interner: StringInterner::with_capacity_and_hasher(cap, hasher),
+		}
+	}
+
+	pub fn get_or_intern<T>(&mut self, val: T) -> PooledStr<Sym, H>
+		where T: Into<String> + AsRef<str>
+	{
+		let sym = self.interner.get_or_intern(val);
+		PooledStr {
+			pool: self,
+			sym,
+		}
+	}
+
+	pub fn get<T>(&self, val: T) -> Option<PooledStr<Sym, H>>
+		where T: AsRef<str>
+	{
+		self.interner.get(val).map(|sym| {
+			PooledStr {
+				pool: self,
+				sym,
+			}
+		})
+	}
+
+	pub fn len(&self) -> usize {
+		self.interner.len()
+	}
+
+	pub fn is_empty(&self) -> bool {
+		self.interner.is_empty()
+	}
+
+	pub fn iter(&self) -> Iter<Sym> {
+		self.interner.iter()
+	}
+
+	pub fn iter_values(&self) -> Values<Sym> {
+		self.interner.iter_values()
+	}
+
+	pub fn shrink_to_fit(&mut self) {
+		self.interner.shrink_to_fit()
+	}
+}

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -1,10 +1,9 @@
-#![allow(missing_docs)]
-
-use {Iter, StringInterner, Symbol, Values};
+use {Iter, StringInterner, Symbol};
 use std::collections::hash_map::RandomState;
 use std::hash::BuildHasher;
 use std::ops::Deref;
 
+/// A reference to an interned string pooled in a `StringPool`.
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct PooledStr<'pool, Sym: Symbol + 'pool = usize, H: BuildHasher + 'pool = RandomState> {
@@ -31,16 +30,27 @@ impl<'pool, Sym: Symbol + 'pool, H: BuildHasher + 'pool> Deref for PooledStr<'po
 }
 
 impl<'pool, Sym: Symbol + 'pool, H: BuildHasher + 'pool> PooledStr<'pool, Sym, H> {
+	/// Resolves this reference to the interned string slice.
+	///
+	/// `PooledStr` dereferences directly to the slice, so prefer `&*pooled`.
 	pub fn resolve(this: &Self) -> &str {
 		this.pool.interner.resolve(this.sym)
 			.expect("PooledStr exists without entry in StringPool")
 	}
 
+	/// Resolves this reference without doing bounds checking.
+	///
+	/// A `PooledStr` should not be able to exist without being valid,
+	/// but the regular `resolve` does the check and panic if this isn't true.
+	///
+	/// `PooledStr` dereferences directly to the slice, so prefer `&*pooled`.
 	pub unsafe fn resolve_unchecked(this: &Self) -> &str {
 		this.pool.interner.resolve_unchecked(this.sym)
 	}
 }
 
+/// A pool for interning strings. The interned strings are given out
+/// as `PooledStr` references rather than just as an opaque index.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct StringPool<Sym: Symbol = usize, H: BuildHasher = RandomState> {
@@ -50,7 +60,9 @@ pub struct StringPool<Sym: Symbol = usize, H: BuildHasher = RandomState> {
 	interner: StringInterner<Sym, H>,
 }
 
-impl<Sym: Symbol> Default for StringPool<Sym> {
+impl<Sym: Symbol> Default for StringPool<Sym>
+	where StringInterner<Sym>: Default
+{
 	fn default() -> Self {
 		StringPool {
 			interner: Default::default(),
@@ -59,12 +71,14 @@ impl<Sym: Symbol> Default for StringPool<Sym> {
 }
 
 impl<Sym: Symbol> StringPool<Sym> {
+	/// Creates a new empty `StringPool`.
 	pub fn new() -> Self {
 		StringPool {
 			interner: StringInterner::new(),
 		}
 	}
 
+	/// Creates a new `StringPool` with the given initial capacity.
 	pub fn with_capacity(cap: usize) -> Self {
 		StringPool {
 			interner: StringInterner::with_capacity(cap),
@@ -73,18 +87,26 @@ impl<Sym: Symbol> StringPool<Sym> {
 }
 
 impl<Sym: Symbol, H: BuildHasher> StringPool<Sym, H> {
+	/// Creates a new empty `StringPool` with the given hasher.
 	pub fn with_hasher(hasher: H) -> Self {
 		StringPool {
 			interner: StringInterner::with_hasher(hasher),
 		}
 	}
 
+	/// Creates a new empty `StringPool` with the given initial capacity and the given hasher.
 	pub fn with_capacity_and_hasher(cap: usize, hasher: H) -> Self {
 		StringPool {
 			interner: StringInterner::with_capacity_and_hasher(cap, hasher),
 		}
 	}
 
+	/// Interns the given value.
+	///
+	/// Returns a `PooledStr` reference to the interned string.
+	///
+	/// This either copies the contents of the string (e.g. for str)
+	/// or moves them into this interner (e.g. for String).
 	pub fn get_or_intern<T>(&mut self, val: T) -> PooledStr<Sym, H>
 		where T: Into<String> + AsRef<str>
 	{
@@ -95,6 +117,7 @@ impl<Sym: Symbol, H: BuildHasher> StringPool<Sym, H> {
 		}
 	}
 
+	/// Returns the given string's pooled reference if existent.
 	pub fn get<T>(&self, val: T) -> Option<PooledStr<Sym, H>>
 		where T: AsRef<str>
 	{
@@ -106,22 +129,22 @@ impl<Sym: Symbol, H: BuildHasher> StringPool<Sym, H> {
 		})
 	}
 
+	/// Returns the number of uniquely stored Strings interned within this interner.
 	pub fn len(&self) -> usize {
 		self.interner.len()
 	}
 
+	/// Returns true if the string interner internes no elements.
 	pub fn is_empty(&self) -> bool {
 		self.interner.is_empty()
 	}
 
+	/// Returns an iterator over the interned strings.
 	pub fn iter(&self) -> Iter<Sym> {
 		self.interner.iter()
 	}
 
-	pub fn iter_values(&self) -> Values<Sym> {
-		self.interner.iter_values()
-	}
-
+	/// Shrinks the capacity of the interner as much as possible.
 	pub fn shrink_to_fit(&mut self) {
 		self.interner.shrink_to_fit()
 	}

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -82,7 +82,7 @@ impl<'a, Sym: Symbol, H: BuildHasher> StringPool<'a, Sym, H> {
 	}
 
 	/// Returns the given string's pooled reference if existent.
-	pub fn get<T>(&self, val: T) -> Option<PooledStr<Sym, H>>
+	pub fn get<T>(&self, val: T) -> Option<PooledStr<'a, Sym, H>>
 		where T: AsRef<str>
 	{
 		self.interner.get(val).map(|sym| {

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -149,3 +149,16 @@ impl<Sym: Symbol, H: BuildHasher> StringPool<Sym, H> {
 		self.interner.shrink_to_fit()
 	}
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_usage() {
+        let mut pool = StringPool::default();
+	    let a1 = pool.get_or_intern("a");
+	    let a2 = pool.get("a").unwrap();
+	    assert_eq!(a1, a2);
+    }
+}

--- a/tests/compile-fail/pooled_str_outlives.rs
+++ b/tests/compile-fail/pooled_str_outlives.rs
@@ -1,0 +1,55 @@
+extern crate string_interner;
+use string_interner::*;
+use string_interner::wrapped::*;
+
+fn case1() {
+	let s_ref;
+	{
+		let mut interner = StringInterner::default();
+		let mut pool = StringPool::new(&mut interner); //~ ERROR does not live long enough
+		s_ref = pool.get_or_intern("case1");
+	}
+	println!("garbage: {:?}", s_ref);
+}
+
+fn case2() {
+	let mut interner = StringInterner::default();
+	let s_ref;
+	{
+		let mut pool = StringPool::new(&mut interner); //~ ERROR does not live long enough
+		s_ref = pool.get_or_intern("case2");
+	}
+	println!("garbage: {:?}", s_ref);
+}
+
+fn case3() {
+	let s;
+	{
+		let mut interner = StringInterner::default();
+		let mut pool = StringPool::new(&mut interner); //~ ERROR does not live long enough
+		s = &*pool.get_or_intern("case3"); //~ ERROR does not live long enough
+	}
+	println!("garbage: {:?}", s);
+}
+
+fn case4() {
+	let mut interner = StringInterner::default();
+	let s;
+	{
+		let mut pool = StringPool::new(&mut interner);
+		s = &*pool.get_or_intern("case4"); //~ ERROR does not live long enough
+	}
+	println!("garbage: {:?}", s);
+}
+
+fn case5() {
+	let mut interner = StringInterner::default();
+	let mut pool = StringPool::new(&mut interner);
+	let s;
+	{
+		s = &*pool.get_or_intern("case5"); //~ ERROR does not live long enough
+	}
+	println!("ok: {:?}", s);
+}
+
+fn main() {}

--- a/tests/compile-fail/pooled_str_outlives.rs
+++ b/tests/compile-fail/pooled_str_outlives.rs
@@ -32,4 +32,16 @@ fn case3() {
 	println!("garbage: {:?}", s_ref);
 }
 
+fn case4() {
+	let mut interner = StringInterner::default();
+	let dangle;
+	{
+		let mut pool = StringPool::new(&mut interner);
+		pool.get_or_intern("dangle");
+		dangle = pool.get("dangle").unwrap();
+	}
+	interner.clear(); //~ ERROR cannot borrow `interner` as mutable more than once
+	println!("{}", &*dangle);
+}
+
 fn main() {}

--- a/tests/compile-fail/pooled_str_outlives.rs
+++ b/tests/compile-fail/pooled_str_outlives.rs
@@ -12,44 +12,24 @@ fn case1() {
 	println!("garbage: {:?}", s_ref);
 }
 
+// OK because s_ref's validity is tied to `interner` not `pool`
 fn case2() {
 	let mut interner = StringInterner::default();
 	let s_ref;
 	{
-		let mut pool = StringPool::new(&mut interner); //~ ERROR does not live long enough
+		let mut pool = StringPool::new(&mut interner);
 		s_ref = pool.get_or_intern("case2");
 	}
-	println!("garbage: {:?}", s_ref);
+	println!("ok: {:?}", s_ref);
 }
 
 fn case3() {
-	let s;
-	{
-		let mut interner = StringInterner::default();
-		let mut pool = StringPool::new(&mut interner); //~ ERROR does not live long enough
-		s = &*pool.get_or_intern("case3"); //~ ERROR does not live long enough
-	}
-	println!("garbage: {:?}", s);
-}
-
-fn case4() {
-	let mut interner = StringInterner::default();
-	let s;
-	{
-		let mut pool = StringPool::new(&mut interner);
-		s = &*pool.get_or_intern("case4"); //~ ERROR does not live long enough
-	}
-	println!("garbage: {:?}", s);
-}
-
-fn case5() {
 	let mut interner = StringInterner::default();
 	let mut pool = StringPool::new(&mut interner);
-	let s;
-	{
-		s = &*pool.get_or_intern("case5"); //~ ERROR does not live long enough
-	}
-	println!("ok: {:?}", s);
+	let s_ref = pool.get_or_intern("case2");
+	drop(pool);
+	drop(interner); //~ ERROR cannot move
+	println!("garbage: {:?}", s_ref);
 }
 
 fn main() {}

--- a/tests/compiletests.rs
+++ b/tests/compiletests.rs
@@ -1,0 +1,19 @@
+extern crate compiletest_rs as compiletest;
+
+use std::path::PathBuf;
+
+fn run_mode(mode: &'static str) {
+	let mut config = compiletest::Config::default();
+
+	config.mode = mode.parse().expect("Invalid mode");
+	config.src_base = PathBuf::from(format!("tests/{}", mode));
+	config.target_rustcflags = Some("-L target/debug/deps".to_string());
+	config.clean_rmeta(); // If your tests import the parent crate, this helps with E0464
+
+	compiletest::run_tests(&config);
+}
+
+#[test]
+fn compile_test() {
+	run_mode("compile-fail");
+}

--- a/tests/compiletests.rs
+++ b/tests/compiletests.rs
@@ -1,4 +1,4 @@
-extern crate compiletest_rs as compiletest;
+/*extern crate compiletest_rs as compiletest;
 
 use std::path::PathBuf;
 
@@ -20,5 +20,8 @@ fn run_mode(mode: &'static str) {
 
 #[test]
 fn compile_test() {
+	// Currently, this test fails on Travis because string-interner is duplicated in the link args
+	// https://travis-ci.org/Robbepop/string-interner/jobs/339735884
+	// FIXME(CAD97): compile-fail tests are therefore disabled until this can be figured out
 	run_mode("compile-fail");
-}
+}*/

--- a/tests/compiletests.rs
+++ b/tests/compiletests.rs
@@ -7,7 +7,12 @@ fn run_mode(mode: &'static str) {
 
 	config.mode = mode.parse().expect("Invalid mode");
 	config.src_base = PathBuf::from(format!("tests/{}", mode));
-	config.target_rustcflags = Some("-L target/debug/deps".to_string());
+	if cfg!(target_os = "windows") {
+		// circumvent laumann/compiletest-rs#81 where it matters most
+		config.target_rustcflags = Some("-L target/debug/deps".to_string());
+	} else {
+		config.link_deps();
+	}
 	config.clean_rmeta(); // If your tests import the parent crate, this helps with E0464
 
 	compiletest::run_tests(&config);


### PR DESCRIPTION
Creates a new pool that wraps the existing interner, with symbols that contain a reference back to the pool.

This means that

(advantages)

1. The symbols can only be used to resolve in the interner they come from
2. The symbols die when the interner dies
3. The symbols can dereference to `&str` directly

(disadvantages)

4. The symbols are one `usize` bigger (due to alignment, this probably means restricting the symbols to just `usize` rather than allowing variance wouldn't hurt, and would ease usage)
5. It's not possible to clear out the pool
6. It's not possible to move the pool

TODO:

- [x] documentation
- [x] tests
- [ ] better names?