### PR TITLE
Preallocate storage using iterator's size hint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,8 +418,9 @@ where
 	where
 		I: IntoIterator<Item = T>,
 	{
-		let mut interner = StringInterner::new();
-		for s in iter.into_iter() {
+		let iter = iter.into_iter();
+		let mut interner = StringInterner::with_capacity(iter.size_hint().0);
+		for s in iter {
 			interner.get_or_intern(s);
 		}
 		interner


### PR DESCRIPTION
This may reduce reallocation by `FromIterator` for some cases when the iterator has non-zero lower bound size hint.