### PR TITLE
Make `Sym::from_usize` safe (avoid using `unsafe`)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,11 @@ impl Symbol for Sym {
 	///
 	/// If the given `usize` is greater than `u32::MAX - 1`.
 	fn from_usize(val: usize) -> Self {
-		assert!(val < u32::MAX as usize);
+		assert!(
+			val < u32::MAX as usize,
+			"Symbol value {} is too large and not supported by `string_interner::Sym` type",
+			val
+		);
 		Sym(NonZeroU32::new((val + 1) as u32).unwrap_or_else(|| {
 			unreachable!("Should never fail because `val + 1` is nonzero and `<= u32::MAX`")
 		}))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,9 @@ impl Symbol for Sym {
 	/// If the given `usize` is greater than `u32::MAX - 1`.
 	fn from_usize(val: usize) -> Self {
 		assert!(val < u32::MAX as usize);
-		Sym(unsafe { NonZeroU32::new_unchecked((val + 1) as u32) })
+		Sym(NonZeroU32::new((val + 1) as u32).unwrap_or_else(|| {
+			unreachable!("Should never fail because `val + 1` is nonzero and `<= u32::MAX`")
+		}))
 	}
 
 	fn to_usize(self) -> usize {


### PR DESCRIPTION
https://github.com/Robbepop/string-interner/blob/f5ffa9d0284b03e0cac397ee1a1d4ce2080f4644/src/lib.rs#L123-L126

This is not UB, but I think this part is not so critical to use `unsafe` (because it is executed only when interning new string and cloning the interner), and can be written in safe Rust without big downside.

I checked generated assembly codes using [godbolt](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(j:1,lang:rust,source:'use+std::%7Bnum::NonZeroU32,+u32%7D%3B%0A%0Apub+fn+from_usize_before(val:+usize)+-%3E+NonZeroU32+%7B%0A++++assert!!(val+%3C+u32::MAX+as+usize)%3B%0A%09unsafe+%7B+NonZeroU32::new_unchecked((val+%2B+1)+as+u32)+%7D%0A%7D%0A%0A%0Apub+fn+from_usize_safe(val:+usize)+-%3E+NonZeroU32+%7B%0A%09assert!!(val+%3C+u32::MAX+as+usize)%3B%0A%09NonZeroU32::new((val+%2B+1)+as+u32).unwrap_or_else(%7C%7C+%7B%0A%09%09unreachable!!(%22Should+never+fail+because+%60val+%2B+1%60+is+nonzero+and+%60%3C%3D+u32::MAX%60%22)%0A%09%7D)%0A%7D%0A'),l:'5',n:'0',o:'Rust+source+%231',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:r1360,filters:(b:'0',binary:'1',commentOnly:'0',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'1',trim:'1'),lang:rust,libs:!(),options:'-O',source:1),l:'5',n:'0',o:'rustc+1.36.0+(Editor+%231,+Compiler+%231)+Rust',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4) with `-O` option.
They have very little difference, and I think it is reasonable cost to avoid using `unsafe`.

Unsafe version:
```
        mov     ecx, 4294967295  // Remember `u32::MAX`.
        cmp     rdi, rcx  // Compare `val` and `u32::MAX`.
        jae     .LBB8_1  // Panic if `val >= u32::MAX`. (`assert!`)
        mov     rax, rdi  // Copy `val` to return value register.
        add     eax, 1  // Increment `val`.
```

Safe version:
```
        mov     ecx, 4294967295  // Remember `u32::MAX`.
        cmp     rdi, rcx  // Compare `val` and `u32::MAX`.
        jae     .LBB9_3  // Panic if `val >= u32::MAX`. (`assert!`)
        mov     rax, rdi  // Copy `val` to return value register.
        inc     eax  // Increment `val`.
        je      .LBB9_4  // [DIFFERENCE] Panic if `EAX` (that is `val + 1`) is zero. The jump should never happen because `val < u32::MAX`.
```