### PR TITLE
Implement `std::iter::Extend` for `StringInterner`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -442,9 +442,7 @@ where
 	{
 		let iter = iter.into_iter();
 		let mut interner = StringInterner::with_capacity(iter.size_hint().0);
-		for s in iter {
-			interner.get_or_intern(s);
-		}
+		interner.extend(iter);
 		interner
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,6 +449,21 @@ where
 	}
 }
 
+impl<T, S> std::iter::Extend<T> for StringInterner<S>
+where
+	S: Symbol,
+	T: Into<String> + AsRef<str>,
+{
+	fn extend<I>(&mut self, iter: I)
+	where
+		I: IntoIterator<Item = T>,
+	{
+		for s in iter {
+			self.get_or_intern(s);
+		}
+	}
+}
+
 /// Iterator over the pairs of associated symbols and interned strings for a `StringInterner`.
 pub struct Iter<'a, S> {
 	iter: iter::Enumerate<slice::Iter<'a, Box<str>>>,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -374,6 +374,51 @@ mod from_iterator {
 	}
 }
 
+mod extend {
+	use super::*;
+
+	#[test]
+	fn empty() {
+		let mut interner = DefaultStringInterner::new();
+		interner.extend(Vec::<&str>::new());
+		assert_eq!(interner, DefaultStringInterner::new(),);
+	}
+
+	#[test]
+	fn simple() {
+		assert_eq!(
+			{
+				let mut interner = DefaultStringInterner::new();
+				interner.extend(vec!["foo", "bar"]);
+				interner
+			},
+			{
+				let mut interner = DefaultStringInterner::new();
+				interner.get_or_intern("foo");
+				interner.get_or_intern("bar");
+				interner
+			}
+		);
+	}
+
+	#[test]
+	fn multiple_same() {
+		assert_eq!(
+			{
+				let mut interner = DefaultStringInterner::new();
+				interner.extend(vec!["foo", "foo"]);
+				interner
+			},
+			{
+				let mut interner = DefaultStringInterner::new();
+				interner.get_or_intern("foo");
+				interner.get_or_intern("foo");
+				interner
+			}
+		);
+	}
+}
+
 // See <https://github.com/Robbepop/string-interner/issues/9>.
 mod clone_and_drop {
 	use super::*;


### PR DESCRIPTION
`StringInterner` implements `FromIterator`, and that means we can add strings to an empty interner through an iterator.
Then, it is natural that we can add strings to also a non-empty interner through an iterator.

Accepted iterator types are same as the already existing `FromIterator` trait impl.