### PR TITLE
Backport clone bugfix on top of 0.6.3

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ pub type DefaultStringInterner = StringInterner<usize>;
 /// 
 /// The main goal of this `StringInterner` is to store String
 /// with as low memory overhead as possible.
-#[derive(Debug, Clone, Eq)]
+#[derive(Debug, Eq)]
 pub struct StringInterner<Sym, H = RandomState>
 	where Sym: Symbol,
 	      H  : BuildHasher
@@ -171,6 +171,20 @@ impl Default for StringInterner<usize, RandomState> {
 	fn default() -> Self {
 		StringInterner::new()
 	}
+}
+
+impl<Sym, H> Clone for StringInterner<Sym, H>
+	where Sym: Symbol,
+	      H  : Clone + BuildHasher
+{
+    fn clone(&self) -> Self {
+        let values = self.values.clone();
+        let mut map: HashMap<InternalStrRef, _, H> = HashMap::with_capacity_and_hasher(values.len(), self.map.hasher().clone());
+        map.extend(
+            values.iter().enumerate().map(|(i,s)| (InternalStrRef::from_str(s), Sym::from_usize(i)))
+        );
+        Self { values, map }
+    }
 }
 
 // About `Send` and `Sync` impls for `StringInterner`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,6 +345,66 @@ impl<Sym, H> StringInterner<Sym, H>
 		self.map.shrink_to_fit();
 		self.values.shrink_to_fit();
 	}
+
+
+	/// Checks whether the all `InternalStrRef`s refer the strigs owned by `self`.
+	///
+	/// For testing purpose only.
+	///
+	/// # Panics
+	///
+	/// Panics if the interner has wrong state. That is:
+	///
+	/// * when `InternalStrRef` refers the address which is not owned by the interner, or
+	/// * when there are `Box<str>` not referred by any `InternalStrRef` owned by the interner.
+	#[cfg(test)]
+	pub(crate) fn assert_internal_str_refs_validity(&self)
+	where
+		Sym: std::fmt::Debug,
+		H: std::fmt::Debug,
+	{
+		// Collect `InternalStrRef` pointers.
+		let mut referred_ptrs = self
+			.map
+			.keys()
+			.map(|s| s.0)
+			.collect::<std::collections::HashSet<_>>();
+		// Remove owned pointers.
+		for (owned_str, owned_ptr) in self.values.iter().map(|v| (&**v, (&**v) as *const str)) {
+			if !referred_ptrs.remove(&owned_ptr) {
+				// `owned` is not in `referred_ptrs`.
+				// It means the `Box<str>` is not found by `get()` and `get_or_intern()`.
+				panic!(
+					"String {:?} at {:?} is not registered to `map`: self={:#?}",
+					owned_str, owned_ptr, self
+				);
+			}
+		}
+		if !referred_ptrs.is_empty() {
+			// `self.map` has some dangling pointers.
+			let values_ptrs = self
+				.values
+				.iter()
+				.map(|v| (&**v, (&**v) as *const str))
+				.collect::<Vec<_>>();
+			panic!(
+				"Dangling pointers found: pointers {:?} are not stored in `values`: \
+				self={:#?}, values_ptrs = {:?}",
+				referred_ptrs, self, values_ptrs
+			);
+		}
+	}
+
+	/// Returns the maximum capacity of the internal storages.
+	///
+	/// Storing `self.max_capacity() + 1` elements in total will cause all storages to be
+	/// reallocated at least once.
+	///
+	/// For testing purpose only.
+	#[cfg(test)]
+	pub(crate) fn max_capacity(&self) -> usize {
+		std::cmp::max(self.map.capacity(), self.values.capacity())
+	}
 }
 
 /// Iterator over the pairs of symbols and interned string for a `StringInterner`.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -164,3 +164,44 @@ fn serde() {
 	let deserialized: DefaultStringInterner = serde_json::from_str(&serialized).unwrap();
 	assert_eq!(interner, deserialized);
 }
+
+
+// See <https://github.com/Robbepop/string-interner/issues/9>.
+mod clone_and_drop {
+	use super::*;
+
+	fn clone_and_drop() -> (DefaultStringInterner, usize) {
+		let mut old = DefaultStringInterner::new();
+		let foo = old.get_or_intern("foo");
+
+		// Return newly created (cloned) interner, and drop the original `old` itself.
+		(old.clone(), foo)
+	}
+
+	#[test]
+	fn no_use_after_free() {
+		let (mut new, foo) = clone_and_drop();
+
+		// This assert may fail if there are use after free bug.
+		// See <https://github.com/Robbepop/string-interner/issues/9> for detail.
+		assert_eq!(
+			new.get_or_intern("foo"),
+			foo,
+			"`foo` should represent the string \"foo\" so they should be equal"
+		);
+	}
+
+	#[test]
+	// Test for new (non-`derive`) `Clone` impl.
+	fn clone() {
+		let mut old = DefaultStringInterner::new();
+		let strings = &["foo", "bar", "baz", "qux", "quux", "corge"];
+		let syms = strings.iter().map(|&s| old.get_or_intern(s)).collect::<Vec<_>>();
+
+		let mut new = old.clone();
+		for (&s, &sym) in strings.iter().zip(&syms) {
+			assert_eq!(new.resolve(sym), Some(s));
+			assert_eq!(new.get_or_intern(s), sym);
+		}
+	}
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -205,3 +205,54 @@ mod clone_and_drop {
 		}
 	}
 }
+
+
+/// Tests safety invariants of `StringInterner`.
+mod internal_str_refs_validity {
+	use super::*;
+
+	/// Tests for interning, reallocation, and cloning.
+	#[test]
+	fn intern_reallocate_clone() {
+		let mut old = DefaultStringInterner::new();
+		old.assert_internal_str_refs_validity();
+		let mut syms_old = Vec::new();
+
+		// Cause allocation to `old`.
+		syms_old.push(old.get_or_intern("0"));
+		old.assert_internal_str_refs_validity();
+		// Fill storage with some elements.
+		for i in 1..old.max_capacity() {
+			syms_old.push(old.get_or_intern(i.to_string()));
+			old.assert_internal_str_refs_validity();
+		}
+		// Lookup all values.
+		for (i, sym) in syms_old.iter().enumerate() {
+			assert_eq!(old.resolve(*sym), Some(i.to_string().as_str()));
+		}
+
+		// Clone the interner.
+		let mut new = old.clone();
+		let mut syms_new = syms_old.clone();
+
+		// Cause reallocation to `old`.
+		for i in old.len()..=old.max_capacity() {
+			syms_old.push(old.get_or_intern(i.to_string()));
+			old.assert_internal_str_refs_validity();
+		}
+		// Cause reallocation to `new`.
+		for i in new.len()..=new.max_capacity() {
+			syms_new.push(new.get_or_intern(i.to_string()));
+			new.assert_internal_str_refs_validity();
+		}
+
+		// Lookup all values.
+		for (i, sym) in syms_old.iter().enumerate() {
+			assert_eq!(old.resolve(*sym), Some(i.to_string().as_str()));
+		}
+		for (i, sym) in syms_new.iter().enumerate() {
+			assert_eq!(new.resolve(*sym), Some(i.to_string().as_str()));
+		}
+	}
+}
+


### PR DESCRIPTION
Hello: I help maintain (& have production dependencies on) https://github.com/m4b/faerie, which depends on string-interner 0.6. We are not able to upgrade to the new API in the 0.7 release, but we require the security fix implemented in #10.

I have backported #10 and the tests from #12 on top of 0.6.3. I have marked the original author, @lo48576 as the author of these commits, since very little is changed from their implementation.

My apologies that a PR onto `master` is not the correct way to accept this patch. This should instead be merged as a new branch called, perhaps, `0.6.x`, starting at the `v0.6.3` tag, and then tagged and released as `0.6.4`.