### PR TITLE
Implementation of the new StringBackend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "string-interner"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Robbepop"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.11.2 - 2020/07/15
+
+- Add new `StringBackend` that is optimized for memory allocations and footprint.
+	- Use it if your memory constraints are most important to you.
+
 ## 0.11.1 - 2020/07/14
 
 Special thanks to [Ten0](https://github.com/Ten0) for help with this release!

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,6 +5,7 @@ use self::setup::{
     BackendBenchmark,
     BenchBucket,
     BenchSimple,
+    BenchString,
     BENCH_LEN_STRINGS,
     BENCH_STRING_LEN,
 };
@@ -76,6 +77,7 @@ fn bench_get_or_intern_static(c: &mut Criterion) {
     }
     bench_for_backend::<BenchSimple>(&mut g);
     bench_for_backend::<BenchBucket>(&mut g);
+    bench_for_backend::<BenchString>(&mut g);
 }
 
 fn bench_get_or_intern_fill_with_capacity(c: &mut Criterion) {
@@ -101,6 +103,7 @@ fn bench_get_or_intern_fill_with_capacity(c: &mut Criterion) {
     }
     bench_for_backend::<BenchSimple>(&mut g);
     bench_for_backend::<BenchBucket>(&mut g);
+    bench_for_backend::<BenchString>(&mut g);
 }
 
 fn bench_get_or_intern_fill(c: &mut Criterion) {
@@ -126,6 +129,7 @@ fn bench_get_or_intern_fill(c: &mut Criterion) {
     }
     bench_for_backend::<BenchSimple>(&mut g);
     bench_for_backend::<BenchBucket>(&mut g);
+    bench_for_backend::<BenchString>(&mut g);
 }
 
 fn bench_get_or_intern_already_filled(c: &mut Criterion) {
@@ -151,6 +155,7 @@ fn bench_get_or_intern_already_filled(c: &mut Criterion) {
     }
     bench_for_backend::<BenchSimple>(&mut g);
     bench_for_backend::<BenchBucket>(&mut g);
+    bench_for_backend::<BenchString>(&mut g);
 }
 
 fn bench_resolve_already_filled(c: &mut Criterion) {
@@ -176,6 +181,7 @@ fn bench_resolve_already_filled(c: &mut Criterion) {
     }
     bench_for_backend::<BenchSimple>(&mut g);
     bench_for_backend::<BenchBucket>(&mut g);
+    bench_for_backend::<BenchString>(&mut g);
 }
 
 fn bench_get_already_filled(c: &mut Criterion) {
@@ -201,6 +207,7 @@ fn bench_get_already_filled(c: &mut Criterion) {
     }
     bench_for_backend::<BenchSimple>(&mut g);
     bench_for_backend::<BenchBucket>(&mut g);
+    bench_for_backend::<BenchString>(&mut g);
 }
 
 fn bench_iter_already_filled(c: &mut Criterion) {
@@ -230,4 +237,5 @@ fn bench_iter_already_filled(c: &mut Criterion) {
     }
     bench_for_backend::<BenchSimple>(&mut g);
     bench_for_backend::<BenchBucket>(&mut g);
+    bench_for_backend::<BenchString>(&mut g);
 }

--- a/benches/setup.rs
+++ b/benches/setup.rs
@@ -3,6 +3,7 @@ use string_interner::{
         Backend,
         BucketBackend,
         SimpleBackend,
+        StringBackend,
     },
     DefaultSymbol,
     StringInterner,
@@ -90,70 +91,45 @@ pub trait BackendBenchmark {
     const NAME: &'static str;
     type Backend: Backend<DefaultSymbol>;
 
-    fn setup() -> StringInternerWith<Self::Backend>;
-    fn setup_with_capacity(cap: usize) -> StringInternerWith<Self::Backend>;
-    fn setup_filled(words: &[String]) -> StringInternerWith<Self::Backend>;
+    fn setup() -> StringInternerWith<Self::Backend> {
+        <StringInternerWith<Self::Backend>>::new()
+    }
+
+    fn setup_with_capacity(cap: usize) -> StringInternerWith<Self::Backend> {
+        <StringInternerWith<Self::Backend>>::with_capacity(cap)
+    }
+
+    fn setup_filled(words: &[String]) -> StringInternerWith<Self::Backend> {
+        words.iter().collect::<StringInternerWith<Self::Backend>>()
+    }
+
     fn setup_filled_with_ids(
         words: &[String],
-    ) -> (StringInternerWith<Self::Backend>, Vec<DefaultSymbol>);
+    ) -> (StringInternerWith<Self::Backend>, Vec<DefaultSymbol>) {
+        let mut interner = <StringInternerWith<Self::Backend>>::new();
+        let mut word_ids = Vec::new();
+        for word in words {
+            let word_id = interner.get_or_intern(word);
+            word_ids.push(word_id);
+        }
+        (interner, word_ids)
+    }
 }
 
 pub struct BenchBucket;
 impl BackendBenchmark for BenchBucket {
     const NAME: &'static str = "BucketBackend";
     type Backend = BucketBackend<DefaultSymbol>;
-
-    fn setup() -> StringInternerWith<Self::Backend> {
-        <StringInternerWith<Self::Backend>>::new()
-    }
-
-    fn setup_with_capacity(cap: usize) -> StringInternerWith<Self::Backend> {
-        <StringInternerWith<Self::Backend>>::with_capacity(cap)
-    }
-
-    fn setup_filled(words: &[String]) -> StringInternerWith<Self::Backend> {
-        words.iter().collect::<StringInternerWith<Self::Backend>>()
-    }
-
-    fn setup_filled_with_ids(
-        words: &[String],
-    ) -> (StringInternerWith<Self::Backend>, Vec<DefaultSymbol>) {
-        let mut interner = <StringInternerWith<Self::Backend>>::new();
-        let mut word_ids = Vec::new();
-        for word in words {
-            let word_id = interner.get_or_intern(word);
-            word_ids.push(word_id);
-        }
-        (interner, word_ids)
-    }
 }
 
 pub struct BenchSimple;
 impl BackendBenchmark for BenchSimple {
     const NAME: &'static str = "SimpleBackend";
     type Backend = SimpleBackend<DefaultSymbol>;
+}
 
-    fn setup() -> StringInternerWith<Self::Backend> {
-        <StringInternerWith<Self::Backend>>::new()
-    }
-
-    fn setup_with_capacity(cap: usize) -> StringInternerWith<Self::Backend> {
-        <StringInternerWith<Self::Backend>>::with_capacity(cap)
-    }
-
-    fn setup_filled(words: &[String]) -> StringInternerWith<Self::Backend> {
-        words.iter().collect::<StringInternerWith<Self::Backend>>()
-    }
-
-    fn setup_filled_with_ids(
-        words: &[String],
-    ) -> (StringInternerWith<Self::Backend>, Vec<DefaultSymbol>) {
-        let mut interner = <StringInternerWith<Self::Backend>>::new();
-        let mut word_ids = Vec::new();
-        for word in words {
-            let word_id = interner.get_or_intern(word);
-            word_ids.push(word_id);
-        }
-        (interner, word_ids)
-    }
+pub struct BenchString;
+impl BackendBenchmark for BenchString {
+    const NAME: &'static str = "StringBackend";
+    type Backend = StringBackend<DefaultSymbol>;
 }

--- a/src/backend/bucket.rs
+++ b/src/backend/bucket.rs
@@ -24,16 +24,18 @@ use core::{
 /// # Usage
 ///
 /// - **Fill:** Efficiency of filling an empty string interner.
-/// - **Query:** Efficiency of interned string look-up given a symbol.
-/// - **Memory:** The number of allocations and overall memory consumption.
+/// - **Resolve:** Efficiency of interned string look-up given a symbol.
+/// - **Allocations:** The number of allocations performed by the backend.
+/// - **Footprint:** The total heap memory consumed by the backend.
 ///
 /// Rating varies between **bad**, **ok** and **good**.
 ///
-/// | Scenario | Rating |
-/// |:---------|:------:|
-/// | Fill     | **good** |
-/// | Query    | **ok** |
-/// | Memory   | **ok** |
+/// | Scenario    |  Rating  |
+/// |:------------|:--------:|
+/// | Fill        | **good** |
+/// | Resolve     | **ok**   |
+/// | Allocations | **good** |
+/// | Footprint   | **ok**   |
 /// | Supports `get_or_intern_static` | **yes** |
 #[derive(Debug)]
 pub struct BucketBackend<S> {

--- a/src/backend/bucket.rs
+++ b/src/backend/bucket.rs
@@ -33,7 +33,7 @@ use core::{
 /// |:---------|:------:|
 /// | Fill     | **good** |
 /// | Query    | **ok** |
-/// | Memory   | **good** |
+/// | Memory   | **ok** |
 /// | Supports `get_or_intern_static` | **yes** |
 #[derive(Debug)]
 pub struct BucketBackend<S> {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -7,11 +7,13 @@
 mod bucket;
 mod interned_str;
 mod simple;
+mod string;
 
 use self::interned_str::InternedStr;
 pub use self::{
     bucket::BucketBackend,
     simple::SimpleBackend,
+    string::StringBackend,
 };
 use crate::{
     DefaultSymbol,

--- a/src/backend/simple.rs
+++ b/src/backend/simple.rs
@@ -24,16 +24,18 @@ use core::{
 /// # Usage
 ///
 /// - **Fill:** Efficiency of filling an empty string interner.
-/// - **Query:** Efficiency of interned string look-up given a symbol.
-/// - **Memory:** The number of allocations and overall memory consumption.
+/// - **Resolve:** Efficiency of interned string look-up given a symbol.
+/// - **Allocations:** The number of allocations performed by the backend.
+/// - **Footprint:** The total heap memory consumed by the backend.
 ///
 /// Rating varies between **bad**, **ok** and **good**.
 ///
-/// | Scenario | Rating |
-/// |:---------|:------:|
-/// | Fill     | **bad** |
-/// | Query    | **good** |
-/// | Memory   | **bad:** many small allocations |
+/// | Scenario    |  Rating  |
+/// |:------------|:--------:|
+/// | Fill        | **bad** |
+/// | Resolve     | **good**   |
+/// | Allocations | **bad** |
+/// | Footprint   | **bad**   |
 /// | Supports `get_or_intern_static` | **no** |
 #[derive(Debug)]
 pub struct SimpleBackend<S> {

--- a/src/backend/string.rs
+++ b/src/backend/string.rs
@@ -1,0 +1,212 @@
+use super::Backend;
+use crate::{
+    compat::{
+        String,
+        Vec,
+    },
+    symbol::expect_valid_symbol,
+    Symbol,
+};
+use core::{
+    convert::TryInto,
+    iter::Enumerate,
+    marker::PhantomData,
+    slice,
+};
+
+/// An interner backend that appends all interned strings together.
+///
+/// # Note
+///
+/// Implementation inspired by [CAD97's](https://github.com/CAD97) research
+/// project [`strena`](https://github.com/CAD97/strena).
+///
+/// # Usage
+///
+/// - **Fill:** Efficiency of filling an empty string interner.
+/// - **Query:** Efficiency of interned string look-up given a symbol.
+/// - **Memory:** The number of allocations and overall memory consumption.
+///
+/// Rating varies between **bad**, **ok** and **good**.
+///
+/// | Scenario | Rating |
+/// |:---------|:------:|
+/// | Fill     | **ok** |
+/// | Query    | **ok** |
+/// | Memory   | **good** |
+/// | Supports `get_or_intern_static` | **no** |
+#[derive(Debug, Clone)]
+pub struct StringBackend<S> {
+    spans: Vec<Span>,
+    buffer: String,
+    marker: PhantomData<fn() -> S>,
+}
+
+/// Represents a `[from, to)` index into the `StringBackend` buffer.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Span {
+    from: u32,
+    to: u32,
+}
+
+impl<S> PartialEq for StringBackend<S>
+where
+    S: Symbol,
+{
+    fn eq(&self, other: &Self) -> bool {
+        for (&lhs, &rhs) in self.spans.iter().zip(other.spans.iter()) {
+            if self.span_to_str(lhs) != self.span_to_str(rhs) {
+                return false
+            }
+        }
+        true
+    }
+}
+
+impl<S> Eq for StringBackend<S> where S: Symbol {}
+
+impl<S> Default for StringBackend<S> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn default() -> Self {
+        Self {
+            spans: Vec::default(),
+            buffer: String::default(),
+            marker: Default::default(),
+        }
+    }
+}
+
+impl<S> StringBackend<S>
+where
+    S: Symbol,
+{
+    /// Returns the next available symbol.
+    fn next_symbol(&self) -> S {
+        expect_valid_symbol(self.spans.len())
+    }
+
+    /// Returns the string associated to the span.
+    fn span_to_str(&self, span: Span) -> &str {
+        // SAFETY: We convert a `String` into its underlying bytes and then
+        //         directly reinterpret it as `&str` again which is safe. Also
+        //         nothing mutates the string in between since this is a `&self`
+        //         method.
+        unsafe {
+            core::str::from_utf8_unchecked(
+                &self.buffer.as_bytes()[(span.from as usize)..(span.to as usize)],
+            )
+        }
+    }
+
+    /// Returns the span for the given symbol if any.
+    fn symbol_to_span(&self, symbol: S) -> Option<Span> {
+        self.spans.get(symbol.to_usize()).copied()
+    }
+
+    /// Returns the span for the given symbol if any.
+    unsafe fn symbol_to_span_unchecked(&self, symbol: S) -> Span {
+        *self.spans.get_unchecked(symbol.to_usize())
+    }
+
+    /// Pushes the given span into the spans and returns its symbol.
+    fn push_span(&mut self, span: Span) -> S {
+        let symbol = self.next_symbol();
+        self.spans.push(span);
+        symbol
+    }
+
+    /// Pushes the given string into the buffer and returns its span.
+    ///
+    /// # Panics
+    ///
+    /// If the backend ran out of symbols.
+    fn push_string(&mut self, string: &str) -> Span {
+        let from = self.buffer.as_bytes().len();
+        self.buffer.push_str(string);
+        let to = self.buffer.as_bytes().len();
+        Span {
+            from: from.try_into().expect("ran out of symbols"),
+            to: to.try_into().expect("ran out of symbols"),
+        }
+    }
+}
+
+impl<S> Backend<S> for StringBackend<S>
+where
+    S: Symbol,
+{
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn with_capacity(cap: usize) -> Self {
+        // According to google the approx. word length is 5.
+        let default_word_len = 5;
+        Self {
+            spans: Vec::with_capacity(cap),
+            buffer: String::with_capacity(cap * default_word_len),
+            marker: Default::default(),
+        }
+    }
+
+    #[inline]
+    fn intern(&mut self, string: &str) -> S {
+        let span = self.push_string(string);
+        self.push_span(span)
+    }
+
+    #[inline]
+    fn resolve(&self, symbol: S) -> Option<&str> {
+        self.symbol_to_span(symbol)
+            .map(|span| self.span_to_str(span))
+    }
+
+    #[inline]
+    unsafe fn resolve_unchecked(&self, symbol: S) -> &str {
+        self.span_to_str(self.symbol_to_span_unchecked(symbol))
+    }
+}
+
+impl<'a, S> IntoIterator for &'a StringBackend<S>
+where
+    S: Symbol,
+{
+    type Item = (S, &'a str);
+    type IntoIter = Iter<'a, S>;
+
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn into_iter(self) -> Self::IntoIter {
+        Self::IntoIter::new(self)
+    }
+}
+
+pub struct Iter<'a, S> {
+    backend: &'a StringBackend<S>,
+    iter: Enumerate<slice::Iter<'a, Span>>,
+}
+
+impl<'a, S> Iter<'a, S> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    pub fn new(backend: &'a StringBackend<S>) -> Self {
+        Self {
+            backend,
+            iter: backend.spans.iter().enumerate(),
+        }
+    }
+}
+
+impl<'a, S> Iterator for Iter<'a, S>
+where
+    S: Symbol,
+{
+    type Item = (S, &'a str);
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter
+            .next()
+            .map(|(id, &span)| (expect_valid_symbol(id), self.backend.span_to_str(span)))
+    }
+}

--- a/src/backend/string.rs
+++ b/src/backend/string.rs
@@ -24,16 +24,18 @@ use core::{
 /// # Usage
 ///
 /// - **Fill:** Efficiency of filling an empty string interner.
-/// - **Query:** Efficiency of interned string look-up given a symbol.
-/// - **Memory:** The number of allocations and overall memory consumption.
+/// - **Resolve:** Efficiency of interned string look-up given a symbol.
+/// - **Allocations:** The number of allocations performed by the backend.
+/// - **Footprint:** The total heap memory consumed by the backend.
 ///
 /// Rating varies between **bad**, **ok** and **good**.
 ///
-/// | Scenario | Rating |
-/// |:---------|:------:|
-/// | Fill     | **ok** |
-/// | Query    | **ok** |
-/// | Memory   | **good** |
+/// | Scenario    |  Rating  |
+/// |:------------|:--------:|
+/// | Fill        | **good** |
+/// | Resolve     | **bad**   |
+/// | Allocations | **good** |
+/// | Footprint   | **good**   |
 /// | Supports `get_or_intern_static` | **no** |
 #[derive(Debug, Clone)]
 pub struct StringBackend<S> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/crate/string-interner/0.11.1")]
+#![doc(html_root_url = "https://docs.rs/crate/string-interner/0.11.2")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -18,11 +18,15 @@ pub trait BackendStats {
 }
 
 impl BackendStats for backend::BucketBackend<DefaultSymbol> {
-    const OVERHEAD: f64 = 10.5;
+    const OVERHEAD: f64 = 12.5;
 }
 
 impl BackendStats for backend::SimpleBackend<DefaultSymbol> {
-    const OVERHEAD: f64 = 10.5;
+    const OVERHEAD: f64 = 12.0;
+}
+
+impl BackendStats for backend::StringBackend<DefaultSymbol> {
+    const OVERHEAD: f64 = 15.5;
 }
 
 macro_rules! gen_tests_for_backend {
@@ -219,4 +223,10 @@ mod simple_backend {
     use super::*;
 
     gen_tests_for_backend!(backend::SimpleBackend<DefaultSymbol>);
+}
+
+mod string_backend {
+    use super::*;
+
+    gen_tests_for_backend!(backend::StringBackend<DefaultSymbol>);
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -18,7 +18,7 @@ pub trait BackendStats {
 }
 
 impl BackendStats for backend::BucketBackend<DefaultSymbol> {
-    const OVERHEAD: f64 = 12.5;
+    const OVERHEAD: f64 = 14.0;
 }
 
 impl BackendStats for backend::SimpleBackend<DefaultSymbol> {
@@ -35,7 +35,8 @@ macro_rules! gen_tests_for_backend {
             crate::StringInterner<DefaultSymbol, $backend, DefaultHashBuilder>;
 
         #[test]
-        fn test_memory_consumption_1() {
+        #[ignore]
+        fn test_memory_consumption() {
             use std::fmt::Write;
             let len_words = 100_000;
             let word_len = 8;


### PR DESCRIPTION
Discussion: https://github.com/CAD97/string-interner-comparison/pull/1#issuecomment-658480869

Promising performance:

```
     Running target/release/deps/bench-d7f2205ae02e5dca
get_or_intern/fill-empty/new/SimpleBackend                                                                            
                        time:   [7.4500 ms 7.4864 ms 7.5249 ms]
                        thrpt:  [13.289 Melem/s 13.358 Melem/s 13.423 Melem/s]
                 change:
                        time:   [+0.2808% +0.9183% +1.6372%] (p = 0.01 < 0.05)
                        thrpt:  [-1.6109% -0.9099% -0.2800%]
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
get_or_intern/fill-empty/new/BucketBackend                                                                            
                        time:   [5.0885 ms 5.1129 ms 5.1387 ms]
                        thrpt:  [19.460 Melem/s 19.558 Melem/s 19.652 Melem/s]
                 change:
                        time:   [+1.0670% +1.6917% +2.3165%] (p = 0.00 < 0.05)
                        thrpt:  [-2.2640% -1.6636% -1.0557%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
get_or_intern/fill-empty/new/StringBackend                                                                             
                        time:   [4.5862 ms 4.5998 ms 4.6143 ms]
                        thrpt:  [21.672 Melem/s 21.740 Melem/s 21.805 Melem/s]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

get_or_intern/fill-empty/with_capacity/SimpleBackend                                                                            
                        time:   [5.5732 ms 5.5998 ms 5.6299 ms]
                        thrpt:  [17.762 Melem/s 17.858 Melem/s 17.943 Melem/s]
                 change:
                        time:   [+1.4600% +2.1331% +2.8516%] (p = 0.00 < 0.05)
                        thrpt:  [-2.7725% -2.0886% -1.4390%]
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
get_or_intern/fill-empty/with_capacity/BucketBackend                                                                             
                        time:   [3.0705 ms 3.0867 ms 3.1041 ms]
                        thrpt:  [32.215 Melem/s 32.397 Melem/s 32.568 Melem/s]
                 change:
                        time:   [-0.9510% +0.3117% +1.3229%] (p = 0.63 > 0.05)
                        thrpt:  [-1.3056% -0.3107% +0.9601%]
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe
get_or_intern/fill-empty/with_capacity/StringBackend                                                                             
                        time:   [2.8111 ms 2.8286 ms 2.8482 ms]
                        thrpt:  [35.110 Melem/s 35.353 Melem/s 35.574 Melem/s]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

get_or_intern/already-filled/SimpleBackend                                                                            
                        time:   [2.1910 ms 2.2041 ms 2.2179 ms]
                        thrpt:  [45.089 Melem/s 45.371 Melem/s 45.641 Melem/s]
                 change:
                        time:   [+0.7968% +1.5768% +2.3758%] (p = 0.00 < 0.05)
                        thrpt:  [-2.3207% -1.5523% -0.7905%]
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
get_or_intern/already-filled/BucketBackend                                                                            
                        time:   [2.1028 ms 2.1126 ms 2.1230 ms]
                        thrpt:  [47.104 Melem/s 47.336 Melem/s 47.556 Melem/s]
                 change:
                        time:   [+1.6993% +2.2954% +2.9815%] (p = 0.00 < 0.05)
                        thrpt:  [-2.8952% -2.2439% -1.6709%]
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
get_or_intern/already-filled/StringBackend                                                                            
                        time:   [2.0683 ms 2.0789 ms 2.0900 ms]
                        thrpt:  [47.846 Melem/s 48.103 Melem/s 48.349 Melem/s]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

get_or_intern_static/SimpleBackend/get_or_intern                                                                             
                        time:   [3.6499 us 3.6655 us 3.6827 us]
                        thrpt:  [14.120 Melem/s 14.186 Melem/s 14.247 Melem/s]
                 change:
                        time:   [-3.3792% -0.1418% +3.0446%] (p = 0.93 > 0.05)
                        thrpt:  [-2.9547% +0.1420% +3.4974%]
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe
get_or_intern_static/SimpleBackend/get_or_intern_static                                                                             
                        time:   [3.6615 us 3.6781 us 3.6972 us]
                        thrpt:  [14.065 Melem/s 14.138 Melem/s 14.202 Melem/s]
                 change:
                        time:   [-2.6053% +1.1428% +4.9501%] (p = 0.56 > 0.05)
                        thrpt:  [-4.7166% -1.1299% +2.6750%]
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) high mild
  10 (10.00%) high severe
get_or_intern_static/BucketBackend/get_or_intern                                                                             
                        time:   [2.4352 us 2.4430 us 2.4511 us]
                        thrpt:  [21.215 Melem/s 21.285 Melem/s 21.353 Melem/s]
                 change:
                        time:   [-6.4083% -4.2665% -1.9641%] (p = 0.00 < 0.05)
                        thrpt:  [+2.0035% +4.4566% +6.8471%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) high mild
  8 (8.00%) high severe
get_or_intern_static/BucketBackend/get_or_intern_static                                                                             
                        time:   [1.7179 us 1.7237 us 1.7299 us]
                        thrpt:  [30.060 Melem/s 30.167 Melem/s 30.270 Melem/s]
                 change:
                        time:   [-7.2920% -5.6826% -4.1399%] (p = 0.00 < 0.05)
                        thrpt:  [+4.3186% +6.0250% +7.8655%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) high mild
  8 (8.00%) high severe
get_or_intern_static/StringBackend/get_or_intern                                                                             
                        time:   [2.0097 us 2.0259 us 2.0465 us]
                        thrpt:  [25.409 Melem/s 25.668 Melem/s 25.875 Melem/s]
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe
get_or_intern_static/StringBackend/get_or_intern_static                                                                             
                        time:   [2.0142 us 2.0235 us 2.0342 us]
                        thrpt:  [25.563 Melem/s 25.698 Melem/s 25.817 Melem/s]
Found 14 outliers among 100 measurements (14.00%)
  6 (6.00%) high mild
  8 (8.00%) high severe

resolve/already-filled/SimpleBackend                                                                            
                        time:   [143.08 us 144.88 us 146.81 us]
                        thrpt:  [681.16 Melem/s 690.24 Melem/s 698.93 Melem/s]
                 change:
                        time:   [-1.8906% +0.1151% +2.0241%] (p = 0.91 > 0.05)
                        thrpt:  [-1.9840% -0.1150% +1.9270%]
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
resolve/already-filled/BucketBackend                                                                             
                        time:   [136.06 us 137.58 us 139.39 us]
                        thrpt:  [717.39 Melem/s 726.87 Melem/s 734.99 Melem/s]
                 change:
                        time:   [-6.0262% -4.7662% -3.2549%] (p = 0.00 < 0.05)
                        thrpt:  [+3.3644% +5.0048% +6.4126%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
resolve/already-filled/StringBackend                                                                             
                        time:   [130.10 us 131.13 us 132.20 us]
                        thrpt:  [756.42 Melem/s 762.59 Melem/s 768.64 Melem/s]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

get/already-filled/SimpleBackend                                                                            
                        time:   [1.8067 ms 1.8204 ms 1.8351 ms]
                        thrpt:  [54.492 Melem/s 54.933 Melem/s 55.349 Melem/s]
                 change:
                        time:   [-0.2075% +0.6951% +1.6473%] (p = 0.15 > 0.05)
                        thrpt:  [-1.6206% -0.6903% +0.2080%]
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
get/already-filled/BucketBackend                                                                             
                        time:   [1.7061 ms 1.7153 ms 1.7248 ms]
                        thrpt:  [57.977 Melem/s 58.299 Melem/s 58.613 Melem/s]
                 change:
                        time:   [-0.5163% +0.1335% +0.7893%] (p = 0.69 > 0.05)
                        thrpt:  [-0.7832% -0.1334% +0.5190%]
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
get/already-filled/StringBackend                                                                             
                        time:   [1.7278 ms 1.7374 ms 1.7472 ms]
                        thrpt:  [57.234 Melem/s 57.557 Melem/s 57.878 Melem/s]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

iter/already-filled/SimpleBackend                                                                            
                        time:   [148.37 us 150.23 us 152.26 us]
                        thrpt:  [656.77 Melem/s 665.66 Melem/s 673.98 Melem/s]
                 change:
                        time:   [+1.8007% +3.2643% +4.8120%] (p = 0.00 < 0.05)
                        thrpt:  [-4.5911% -3.1611% -1.7688%]
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
iter/already-filled/BucketBackend                                                                             
                        time:   [169.81 us 171.16 us 172.59 us]
                        thrpt:  [579.39 Melem/s 584.25 Melem/s 588.88 Melem/s]
                 change:
                        time:   [+7.0769% +8.2376% +9.3602%] (p = 0.00 < 0.05)
                        thrpt:  [-8.5591% -7.6106% -6.6092%]
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
iter/already-filled/StringBackend                                                                             
                        time:   [143.50 us 144.51 us 145.57 us]
                        thrpt:  [686.95 Melem/s 691.97 Melem/s 696.84 Melem/s]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

     Running target/release/deps/setup-e81bd755c8133c28

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```