### PR TITLE
Implement new Send + Sync bucket backend

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,6 +4,7 @@ use self::setup::{
     generate_test_strings,
     BackendBenchmark,
     BenchBucket,
+    BenchBucket2,
     BenchSimple,
     BenchString,
     BENCH_LEN_STRINGS,
@@ -77,6 +78,7 @@ fn bench_get_or_intern_static(c: &mut Criterion) {
     }
     bench_for_backend::<BenchSimple>(&mut g);
     bench_for_backend::<BenchBucket>(&mut g);
+    bench_for_backend::<BenchBucket2>(&mut g);
     bench_for_backend::<BenchString>(&mut g);
 }
 
@@ -103,6 +105,7 @@ fn bench_get_or_intern_fill_with_capacity(c: &mut Criterion) {
     }
     bench_for_backend::<BenchSimple>(&mut g);
     bench_for_backend::<BenchBucket>(&mut g);
+    bench_for_backend::<BenchBucket2>(&mut g);
     bench_for_backend::<BenchString>(&mut g);
 }
 
@@ -129,6 +132,7 @@ fn bench_get_or_intern_fill(c: &mut Criterion) {
     }
     bench_for_backend::<BenchSimple>(&mut g);
     bench_for_backend::<BenchBucket>(&mut g);
+    bench_for_backend::<BenchBucket2>(&mut g);
     bench_for_backend::<BenchString>(&mut g);
 }
 
@@ -155,6 +159,7 @@ fn bench_get_or_intern_already_filled(c: &mut Criterion) {
     }
     bench_for_backend::<BenchSimple>(&mut g);
     bench_for_backend::<BenchBucket>(&mut g);
+    bench_for_backend::<BenchBucket2>(&mut g);
     bench_for_backend::<BenchString>(&mut g);
 }
 
@@ -181,6 +186,7 @@ fn bench_resolve_already_filled(c: &mut Criterion) {
     }
     bench_for_backend::<BenchSimple>(&mut g);
     bench_for_backend::<BenchBucket>(&mut g);
+    bench_for_backend::<BenchBucket2>(&mut g);
     bench_for_backend::<BenchString>(&mut g);
 }
 
@@ -207,6 +213,7 @@ fn bench_get_already_filled(c: &mut Criterion) {
     }
     bench_for_backend::<BenchSimple>(&mut g);
     bench_for_backend::<BenchBucket>(&mut g);
+    bench_for_backend::<BenchBucket2>(&mut g);
     bench_for_backend::<BenchString>(&mut g);
 }
 
@@ -237,5 +244,6 @@ fn bench_iter_already_filled(c: &mut Criterion) {
     }
     bench_for_backend::<BenchSimple>(&mut g);
     bench_for_backend::<BenchBucket>(&mut g);
+    bench_for_backend::<BenchBucket2>(&mut g);
     bench_for_backend::<BenchString>(&mut g);
 }

--- a/benches/setup.rs
+++ b/benches/setup.rs
@@ -2,6 +2,7 @@ use string_interner::{
     backend::{
         Backend,
         BucketBackend,
+        BucketBackend2,
         SimpleBackend,
         StringBackend,
     },
@@ -120,6 +121,12 @@ pub struct BenchBucket;
 impl BackendBenchmark for BenchBucket {
     const NAME: &'static str = "BucketBackend";
     type Backend = BucketBackend<DefaultSymbol>;
+}
+
+pub struct BenchBucket2;
+impl BackendBenchmark for BenchBucket2 {
+    const NAME: &'static str = "BucketBackend2";
+    type Backend = BucketBackend2<DefaultSymbol>;
 }
 
 pub struct BenchSimple;

--- a/src/backend/bucket2.rs
+++ b/src/backend/bucket2.rs
@@ -1,0 +1,342 @@
+#![cfg(feature = "backends")]
+
+use super::Backend;
+use crate::{
+    compat::{
+        String,
+        Vec,
+    },
+    symbol::expect_valid_symbol,
+    Symbol,
+};
+use core::{
+    convert::TryInto,
+    iter::Enumerate,
+    marker::PhantomData,
+    slice,
+};
+
+/// An interner backend that reduces memory allocations by using string buckets.
+///
+/// # Note
+///
+/// Implementation inspired by matklad's blog post that can be found here:
+/// https://matklad.github.io/2020/03/22/fast-simple-rust-interner.html
+///
+/// # Usage
+///
+/// - **Fill:** Efficiency of filling an empty string interner.
+/// - **Resolve:** Efficiency of interned string look-up given a symbol.
+/// - **Allocations:** The number of allocations performed by the backend.
+/// - **Footprint:** The total heap memory consumed by the backend.
+///
+/// Rating varies between **bad**, **ok** and **good**.
+///
+/// | Scenario    |  Rating  |
+/// |:------------|:--------:|
+/// | Fill        | **good** |
+/// | Resolve     | **ok**   |
+/// | Allocations | **good** |
+/// | Footprint   | **ok**   |
+/// | Supports `get_or_intern_static` | **yes** |
+/// | `Send` + `Sync` | **yes** |
+#[derive(Debug)]
+pub struct BucketBackend<S> {
+    spans: Vec<InternedSpan>,
+    head: String,
+    full: Vec<String>,
+    marker: PhantomData<fn() -> S>,
+}
+
+/// Denotes a single interned string.
+///
+/// # Note
+///
+/// In order to reconstruct a string from this information two look-ups are
+/// necessary since we only store the `end` position and not the `start`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct InternedSpan {
+    /// The bucket ID of the interned string.
+    bucket_id: BucketId,
+    /// The end index of the string within the bucket.
+    end: u32,
+}
+
+/// The identifier of a bucket.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct BucketId {
+    value: u32,
+}
+
+impl BucketId {
+    /// Returns the `u32` identifier.
+    pub fn get(self) -> u32 {
+        self.value
+    }
+}
+
+impl<S> Default for BucketBackend<S> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn default() -> Self {
+        Self {
+            spans: Vec::new(),
+            head: String::new(),
+            full: Vec::new(),
+            marker: Default::default(),
+        }
+    }
+}
+
+impl<S> Backend<S> for BucketBackend<S>
+where
+    S: Symbol,
+{
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn with_capacity(cap: usize) -> Self {
+        Self {
+            spans: Vec::with_capacity(cap),
+            head: String::with_capacity(cap),
+            full: Vec::new(),
+            marker: Default::default(),
+        }
+    }
+
+    #[inline]
+    fn intern(&mut self, string: &str) -> S {
+        let span = self.alloc(string);
+        let symbol = self.push_span(span);
+        symbol
+    }
+
+    #[inline]
+    fn resolve(&self, symbol: S) -> Option<&str> {
+        self.symbol_to_string(symbol)
+    }
+
+    #[inline]
+    unsafe fn resolve_unchecked(&self, symbol: S) -> &str {
+        self.symbol_to_string_unchecked(symbol)
+    }
+}
+
+impl<S> BucketBackend<S>
+where
+    S: Symbol,
+{
+    /// Returns the next available symbol.
+    fn next_symbol(&self) -> S {
+        expect_valid_symbol(self.spans.len())
+    }
+
+    /// Returns the bucket ID of the current head bucket.
+    fn head_bucket_id(&self) -> BucketId {
+        BucketId {
+            value: self.full.len() as u32,
+        }
+    }
+
+    /// Returns the previous symbol of the given symbol.
+    /// Returns the given symbol if it has no previous symbol.
+    fn prev_symbol(symbol: S) -> Option<S> {
+        Symbol::try_from_usize(symbol.to_usize().wrapping_sub(1))
+    }
+
+    /// Returns the string associated with the given symbol if any.
+    fn symbol_to_string(&self, symbol: S) -> Option<&str> {
+        let span = self.spans.get(symbol.to_usize()).copied()?;
+        let prev = Self::prev_symbol(symbol)
+            .map(|symbol| {
+                self.spans
+                    .get(symbol.to_usize())
+                    .copied()
+                    .expect("encountered invalid symbol")
+            })
+            .unwrap_or_else(|| {
+                InternedSpan {
+                    bucket_id: span.bucket_id,
+                    end: 0,
+                }
+            });
+        let start = if prev.bucket_id == span.bucket_id {
+            prev.end as usize
+        } else {
+            0
+        };
+        let end = span.end as usize;
+        let string = unsafe {
+            core::str::from_utf8_unchecked(
+                &self.bucket_id_to_bucket(span.bucket_id).as_bytes()[start..end],
+            )
+        };
+        Some(string)
+    }
+
+    /// Returns the string associated with the given symbol if any.
+    unsafe fn symbol_to_string_unchecked(&self, symbol: S) -> &str {
+        let span = self.spans.get_unchecked(symbol.to_usize());
+        let prev = Self::prev_symbol(symbol)
+            .map(|symbol| {
+                self.spans
+                    .get(symbol.to_usize())
+                    .copied()
+                    .expect("encountered invalid symbol")
+            })
+            .unwrap_or_else(|| {
+                InternedSpan {
+                    bucket_id: span.bucket_id,
+                    end: 0,
+                }
+            });
+        let start = if prev.bucket_id == span.bucket_id {
+            prev.end as usize
+        } else {
+            0
+        };
+        let end = span.end as usize;
+        core::str::from_utf8_unchecked(
+            &self.bucket_id_to_bucket(span.bucket_id).as_bytes()[start..end],
+        )
+    }
+
+    /// Returns the bucket for the given bucket ID.
+    fn bucket_id_to_bucket(&self, bucket_id: BucketId) -> &str {
+        debug_assert!(bucket_id.get() as usize <= self.full.len());
+        self.full
+            .get(bucket_id.get() as usize)
+            .unwrap_or_else(|| &self.head)
+    }
+
+    /// Pushes the given interned span into the spans and returns its symbol.
+    fn push_span(&mut self, span: InternedSpan) -> S {
+        let symbol = self.next_symbol();
+        self.spans.push(span);
+        symbol
+    }
+
+    /// Interns a new string into the backend and returns a reference to it.
+    fn alloc(&mut self, string: &str) -> InternedSpan {
+        let cap = self.head.capacity();
+        if cap < self.head.len() + string.len() {
+            let new_cap = (usize::max(cap, string.len()) + 1).next_power_of_two();
+            let new_head = String::with_capacity(new_cap);
+            let old_head = core::mem::replace(&mut self.head, new_head);
+            self.full.push(old_head);
+        }
+        let end = {
+            let start = self.head.len();
+            self.head.push_str(string);
+            (start + string.len())
+                .try_into()
+                .expect("encountered out of bounds end range")
+        };
+        InternedSpan {
+            bucket_id: self.head_bucket_id(),
+            end,
+        }
+    }
+}
+
+impl<S> Clone for BucketBackend<S>
+where
+    S: Symbol,
+{
+    fn clone(&self) -> Self {
+        Self {
+            spans: self.spans.clone(),
+            head: self.head.clone(),
+            full: self.full.clone(),
+            marker: Default::default(),
+        }
+    }
+}
+
+impl<S> Eq for BucketBackend<S> where S: Symbol {}
+
+impl<S> PartialEq for BucketBackend<S>
+where
+    S: Symbol,
+{
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn eq(&self, other: &Self) -> bool {
+        let self_symbols = self
+            .spans
+            .iter()
+            .enumerate()
+            .map(|(index, _)| expect_valid_symbol(index))
+            .map(|symbol| {
+                self.symbol_to_string(symbol)
+                    .expect("encountered invalid symbol")
+            });
+        let other_symbols = other
+            .spans
+            .iter()
+            .enumerate()
+            .map(|(index, _)| expect_valid_symbol(index))
+            .map(|symbol| {
+                other
+                    .symbol_to_string(symbol)
+                    .expect("encountered invalid symbol")
+            });
+        for (lhs, rhs) in self_symbols.zip(other_symbols) {
+            if lhs != rhs {
+                return false
+            }
+        }
+        true
+    }
+}
+
+impl<'a, S> IntoIterator for &'a BucketBackend<S>
+where
+    S: Symbol,
+{
+    type Item = (S, &'a str);
+    type IntoIter = Iter<'a, S>;
+
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn into_iter(self) -> Self::IntoIter {
+        Self::IntoIter::new(self)
+    }
+}
+
+pub struct Iter<'a, S> {
+    backend: &'a BucketBackend<S>,
+    iter: Enumerate<slice::Iter<'a, InternedSpan>>,
+    symbol_marker: PhantomData<fn() -> S>,
+}
+
+impl<'a, S> Iter<'a, S> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    pub fn new(backend: &'a BucketBackend<S>) -> Self {
+        Self {
+            backend,
+            iter: backend.spans.iter().enumerate(),
+            symbol_marker: Default::default(),
+        }
+    }
+}
+
+impl<'a, S> Iterator for Iter<'a, S>
+where
+    S: Symbol,
+{
+    type Item = (S, &'a str);
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|(id, _)| {
+            let symbol = expect_valid_symbol(id);
+            (
+                symbol,
+                self.backend
+                    .symbol_to_string(symbol)
+                    .expect("encountered invalid symbol"),
+            )
+        })
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -5,6 +5,7 @@
 //! find the backend that suits their use case best.
 
 mod bucket;
+mod bucket2;
 mod interned_str;
 mod simple;
 mod string;
@@ -13,6 +14,7 @@ mod string;
 use self::interned_str::InternedStr;
 #[cfg(feature = "backends")]
 pub use self::{
+    bucket2::BucketBackend as BucketBackend2,
     bucket::BucketBackend,
     simple::SimpleBackend,
     string::StringBackend,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,6 +21,10 @@ impl BackendStats for backend::BucketBackend<DefaultSymbol> {
     const OVERHEAD: f64 = 14.0;
 }
 
+impl BackendStats for backend::BucketBackend2<DefaultSymbol> {
+    const OVERHEAD: f64 = 14.0;
+}
+
 impl BackendStats for backend::SimpleBackend<DefaultSymbol> {
     const OVERHEAD: f64 = 12.0;
 }
@@ -218,6 +222,12 @@ mod bucket_backend {
     use super::*;
 
     gen_tests_for_backend!(backend::BucketBackend<DefaultSymbol>);
+}
+
+mod bucket_backend2 {
+    use super::*;
+
+    gen_tests_for_backend!(backend::BucketBackend2<DefaultSymbol>);
 }
 
 mod simple_backend {


### PR DESCRIPTION
This is just an experiment.

## Benchmarks

Below are some benchmarks between the current `BucketBackend` and the new `BucketBackend2`:
The observation is that `BucketBackend2` is slower for all benchmarks, especially for `resolve` and operations that depend on it (iteration).
Also it can no longer profit from the `&'static str` optimizations.

```
get_or_intern/fill-empty/new/BucketBackend                                                                            
                        time:   [5.0048 ms 5.0314 ms 5.0615 ms]
                        thrpt:  [19.757 Melem/s 19.875 Melem/s 19.981 Melem/s]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
get_or_intern/fill-empty/new/BucketBackend2                                                                            
                        time:   [5.6928 ms 5.7442 ms 5.8009 ms]
                        thrpt:  [17.239 Melem/s 17.409 Melem/s 17.566 Melem/s]
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe

get_or_intern/fill-empty/with_capacity/BucketBackend                                                                             
                        time:   [3.1060 ms 3.1230 ms 3.1450 ms]
                        thrpt:  [31.796 Melem/s 32.021 Melem/s 32.196 Melem/s]
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
get_or_intern/fill-empty/with_capacity/BucketBackend2                                                                             
                        time:   [3.4833 ms 3.5022 ms 3.5231 ms]
                        thrpt:  [28.384 Melem/s 28.553 Melem/s 28.708 Melem/s]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

get_or_intern/already-filled/BucketBackend                                                                             
                        time:   [2.1022 ms 2.1103 ms 2.1187 ms]
                        thrpt:  [47.199 Melem/s 47.387 Melem/s 47.569 Melem/s]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
get_or_intern/already-filled/BucketBackend2                                                                            
                        time:   [2.4757 ms 2.4851 ms 2.4950 ms]
                        thrpt:  [40.080 Melem/s 40.239 Melem/s 40.393 Melem/s]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

get_or_intern_static/BucketBackend/get_or_intern                                                                             
                        time:   [2.5550 us 2.5767 us 2.6074 us]
                        thrpt:  [19.943 Melem/s 20.181 Melem/s 20.353 Melem/s]
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe
get_or_intern_static/BucketBackend/get_or_intern_static                                                                             
                        time:   [1.8322 us 1.8396 us 1.8476 us]
                        thrpt:  [28.145 Melem/s 28.266 Melem/s 28.382 Melem/s]
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe
get_or_intern_static/BucketBackend2/get_or_intern                                                                             
                        time:   [2.8893 us 2.9084 us 2.9328 us]
                        thrpt:  [17.731 Melem/s 17.879 Melem/s 17.997 Melem/s]
Found 15 outliers among 100 measurements (15.00%)
  3 (3.00%) high mild
  12 (12.00%) high severe
get_or_intern_static/BucketBackend2/get_or_intern_static                                                                             
                        time:   [2.8764 us 2.8869 us 2.8996 us]
                        thrpt:  [17.934 Melem/s 18.013 Melem/s 18.078 Melem/s]
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) high mild
  11 (11.00%) high severe

resolve/already-filled/BucketBackend                                                                             
                        time:   [135.34 us 136.42 us 137.55 us]
                        thrpt:  [727.00 Melem/s 733.02 Melem/s 738.89 Melem/s]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
resolve/already-filled/BucketBackend2                                                                            
                        time:   [303.20 us 304.92 us 306.86 us]
                        thrpt:  [325.89 Melem/s 327.95 Melem/s 329.82 Melem/s]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

get/already-filled/BucketBackend                                                                             
                        time:   [1.7385 ms 1.7478 ms 1.7587 ms]
                        thrpt:  [56.859 Melem/s 57.213 Melem/s 57.520 Melem/s]
Found 10 outliers among 100 measurements (10.00%)
  8 (8.00%) high mild
  2 (2.00%) high severe
get/already-filled/BucketBackend2                                                                             
                        time:   [2.1611 ms 2.1693 ms 2.1780 ms]
                        thrpt:  [45.913 Melem/s 46.099 Melem/s 46.273 Melem/s]
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe

iter/already-filled/BucketBackend                                                                             
                        time:   [158.70 us 159.73 us 160.83 us]
                        thrpt:  [621.77 Melem/s 626.05 Melem/s 630.13 Melem/s]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
iter/already-filled/BucketBackend2                                                                             
                        time:   [281.18 us 283.10 us 285.18 us]
                        thrpt:  [350.65 Melem/s 353.23 Melem/s 355.64 Melem/s]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
```