### PR TITLE
Add shrink_to_fit() to StringInterner via Backend

### DIFF
--- a/src/backend/bucket/fixed_str.rs
+++ b/src/backend/bucket/fixed_str.rs
@@ -65,4 +65,10 @@ impl FixedString {
             },
         ))
     }
+
+    /// Shrink capacity to fit the contents exactly.
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {
+        self.contents.shrink_to_fit();
+    }
 }

--- a/src/backend/bucket/fixed_str.rs
+++ b/src/backend/bucket/fixed_str.rs
@@ -67,7 +67,6 @@ impl FixedString {
     }
 
     /// Shrink capacity to fit the contents exactly.
-    #[inline]
     pub fn shrink_to_fit(&mut self) {
         self.contents.shrink_to_fit();
     }

--- a/src/backend/bucket/mod.rs
+++ b/src/backend/bucket/mod.rs
@@ -107,6 +107,13 @@ where
     }
 
     #[inline]
+    fn shrink_to_fit(&mut self) {
+        self.spans.shrink_to_fit();
+        self.head.shrink_to_fit();
+        self.full.shrink_to_fit();
+    }
+
+    #[inline]
     fn resolve(&self, symbol: S) -> Option<&str> {
         self.spans
             .get(symbol.to_usize())
@@ -117,6 +124,7 @@ where
     unsafe fn resolve_unchecked(&self, symbol: S) -> &str {
         self.spans.get_unchecked(symbol.to_usize()).as_str()
     }
+
 }
 
 impl<S> BucketBackend<S>

--- a/src/backend/bucket/mod.rs
+++ b/src/backend/bucket/mod.rs
@@ -106,7 +106,6 @@ where
         self.push_span(interned)
     }
 
-    #[inline]
     fn shrink_to_fit(&mut self) {
         self.spans.shrink_to_fit();
         self.head.shrink_to_fit();
@@ -124,7 +123,6 @@ where
     unsafe fn resolve_unchecked(&self, symbol: S) -> &str {
         self.spans.get_unchecked(symbol.to_usize()).as_str()
     }
-
 }
 
 impl<S> BucketBackend<S>

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -66,6 +66,9 @@ where
         self.intern(string)
     }
 
+    /// Shrink backend capacity to fit interned symbols exactly.
+    fn shrink_to_fit(&mut self);
+
     /// Resolves the given symbol to its original string contents.
     fn resolve(&self, symbol: S) -> Option<&str>;
 

--- a/src/backend/simple.rs
+++ b/src/backend/simple.rs
@@ -75,7 +75,6 @@ where
         symbol
     }
 
-    #[inline]
     fn shrink_to_fit(&mut self) {
         self.strings.shrink_to_fit()
     }

--- a/src/backend/simple.rs
+++ b/src/backend/simple.rs
@@ -76,6 +76,11 @@ where
     }
 
     #[inline]
+    fn shrink_to_fit(&mut self) {
+        self.strings.shrink_to_fit()
+    }
+
+    #[inline]
     fn resolve(&self, symbol: S) -> Option<&str> {
         self.strings.get(symbol.to_usize()).map(|pinned| &**pinned)
     }

--- a/src/backend/string.rs
+++ b/src/backend/string.rs
@@ -180,7 +180,6 @@ where
             .map(|span| self.span_to_str(span))
     }
 
-    #[inline]
     fn shrink_to_fit(&mut self) {
         self.ends.shrink_to_fit();
         self.buffer.shrink_to_fit();

--- a/src/backend/string.rs
+++ b/src/backend/string.rs
@@ -181,6 +181,12 @@ where
     }
 
     #[inline]
+    fn shrink_to_fit(&mut self) {
+        self.ends.shrink_to_fit();
+        self.buffer.shrink_to_fit();
+    }
+
+    #[inline]
     unsafe fn resolve_unchecked(&self, symbol: S) -> &str {
         self.span_to_str(self.symbol_to_span_unchecked(symbol))
     }

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -275,7 +275,6 @@ where
     }
 
     /// Shrink backend capacity to fit the interned strings exactly.
-    #[inline]
     pub fn shrink_to_fit(&mut self) {
         self.backend.shrink_to_fit()
     }

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -274,6 +274,12 @@ where
         self.get_or_intern_using(string, B::intern_static)
     }
 
+    /// Shrink backend capacity to fit the interned strings exactly.
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {
+        self.backend.shrink_to_fit()
+    }
+
     /// Returns the string for the given symbol if any.
     #[inline]
     pub fn resolve(&self, symbol: S) -> Option<&str> {


### PR DESCRIPTION
Motivation:
once a large dataset has been interned and will be treated as immutable for querying, this can optimize the memory requirements 