### PR TITLE
Fix undefined behaviour in `shrink_to_fit`

### DIFF
--- a/src/backend/bucket/fixed_str.rs
+++ b/src/backend/bucket/fixed_str.rs
@@ -63,4 +63,9 @@ impl FixedString {
     pub fn shrink_to_fit(&mut self) {
         self.contents.shrink_to_fit();
     }
+
+    /// Return a reference to the inner str
+    pub fn as_str(&self) -> &str {
+        self.contents.as_str()
+    }
 }

--- a/src/backend/bucket/interned_str.rs
+++ b/src/backend/bucket/interned_str.rs
@@ -29,7 +29,7 @@ impl InternedStr {
     #[inline]
     pub(super) fn as_str(&self) -> &str {
         // SAFETY: This is safe since we only ever operate on interned `str`
-        //         that are never moved around in memory to avoid danling
+        //         that are never moved around in memory to avoid dangling
         //         references.
         unsafe { self.ptr.as_ref() }
     }

--- a/src/backend/bucket/mod.rs
+++ b/src/backend/bucket/mod.rs
@@ -231,16 +231,18 @@ impl<S> Clone for BucketBackend<S> {
             self.head.capacity() + self.full.iter().fold(0, |lhs, rhs| lhs + rhs.len());
         let mut head = FixedString::with_capacity(new_head_cap);
         let mut spans = Vec::with_capacity(self.spans.len());
-        for span in &self.spans {
+        let mut unpinned = Vec::with_capacity(self.spans.len());
+        for (index, span) in self.spans.iter().enumerate() {
             let string = span.as_str();
             let interned = head
                 .push_str(string)
                 .expect("encountered invalid head capacity");
             spans.push(interned);
+            unpinned.push(index)
         }
         Self {
             spans,
-            unpinned: self.unpinned.clone(),
+            unpinned,
             head,
             full: Vec::new(),
             marker: Default::default(),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -379,8 +379,10 @@ macro_rules! gen_tests_for_backend {
             let mut interner = StringInterner::with_capacity(100);
             // Insert 3 unique strings:
             let aa = interner.get_or_intern("aa").to_usize();
-            let bb = interner.get_or_intern("bb").to_usize();
+            let bb = interner.get_or_intern_static("bb").to_usize();
             let cc = interner.get_or_intern("cc").to_usize();
+            let dd = interner.get_or_intern_static("dd").to_usize();
+            let ee = interner.get_or_intern("ee").to_usize();
 
             interner.shrink_to_fit();
 
@@ -399,7 +401,59 @@ macro_rules! gen_tests_for_backend {
                 cc,
                 "'cc' did not produce the same symbol",
             );
-            assert_eq!(interner.len(), 3);
+            assert_eq!(
+                interner.get_or_intern("dd").to_usize(),
+                dd,
+                "'dd' did not produce the same symbol",
+            );
+            assert_eq!(
+                interner.get_or_intern("ee").to_usize(),
+                ee,
+                "'ee' did not produce the same symbol",
+            );
+            assert_eq!(interner.len(), 5);
+        }
+
+        #[test]
+        fn shrink_to_fit_cloned_works() {
+            let mut interner = StringInterner::with_capacity(100);
+            // Insert 3 unique strings:
+            let aa = interner.get_or_intern("aa").to_usize();
+            let bb = interner.get_or_intern_static("bb").to_usize();
+            let cc = interner.get_or_intern("cc").to_usize();
+            let dd = interner.get_or_intern_static("dd").to_usize();
+            let ee = interner.get_or_intern("ee").to_usize();
+
+            let mut interner = interner.clone();
+
+            interner.shrink_to_fit();
+
+            assert_eq!(
+                interner.get_or_intern("aa").to_usize(),
+                aa,
+                "'aa' did not produce the same symbol",
+            );
+            assert_eq!(
+                interner.get_or_intern("bb").to_usize(),
+                bb,
+                "'bb' did not produce the same symbol",
+            );
+            assert_eq!(
+                interner.get_or_intern("cc").to_usize(),
+                cc,
+                "'cc' did not produce the same symbol",
+            );
+            assert_eq!(
+                interner.get_or_intern("dd").to_usize(),
+                dd,
+                "'dd' did not produce the same symbol",
+            );
+            assert_eq!(
+                interner.get_or_intern("ee").to_usize(),
+                ee,
+                "'ee' did not produce the same symbol",
+            );
+            assert_eq!(interner.len(), 5);
         }
     };
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -373,6 +373,34 @@ macro_rules! gen_tests_for_backend {
             let expected_iter = symbols.into_iter().zip(strings);
             assert!(Iterator::eq(expected_iter, &interner));
         }
+
+        #[test]
+        fn shrink_to_fit_works() {
+            let mut interner = StringInterner::with_capacity(100);
+            // Insert 3 unique strings:
+            let aa = interner.get_or_intern("aa").to_usize();
+            let bb = interner.get_or_intern("bb").to_usize();
+            let cc = interner.get_or_intern("cc").to_usize();
+
+            interner.shrink_to_fit();
+
+            assert_eq!(
+                interner.get_or_intern("aa").to_usize(),
+                aa,
+                "'aa' did not produce the same symbol",
+            );
+            assert_eq!(
+                interner.get_or_intern("bb").to_usize(),
+                bb,
+                "'bb' did not produce the same symbol",
+            );
+            assert_eq!(
+                interner.get_or_intern("cc").to_usize(),
+                cc,
+                "'cc' did not produce the same symbol",
+            );
+            assert_eq!(interner.len(), 3);
+        }
     };
 }
 


### PR DESCRIPTION
Fixes #46 and adds a test to avoid future regressions.

Since having a big memory footprint was a big no no, I had to do some pointer shenanigans to reassign the spans when a reallocation occurs. Miri doesn't report any UB, so this should be fine :)