### PR TITLE
Add const new_uninit to existing crate symbols

### DIFF
--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -70,6 +70,20 @@ macro_rules! gen_symbol_for {
             value: $non_zero,
         }
 
+        impl $name {
+            /// Creates an invalid symbol that can be used as a placeholder.
+            ///
+            /// # Safety
+            ///
+            /// Trying to resolve returned symbol is always undefined behavior.
+            #[inline]
+            pub const unsafe fn new_uninit() -> Self {
+                unsafe {
+                    Self { value: <$non_zero>::new_unchecked(0) }
+                }
+            }
+        }
+
         impl Symbol for $name {
             #[inline]
             fn try_from_usize(index: usize) -> Option<Self> {


### PR DESCRIPTION
Added method allows creating placeholder values.

This is required in const contexts where the actual value of the symbol is not needed such as using the symbols in enums that must be `Copy`able with methods such as `std::mem::discriminant` (when const impl gets stabilized (soon-ish)).

Namely, in my case this allows me to do the following:
```rust
const DISCRIMINANT_RAW: Discriminant<TextPart> =
    unsafe { std::mem::discriminant(&TextPart::Raw(SymbolU32::new_uninit())) };
```

In some other cases, using an `Option<Symbol_>` might be sub-optimal and make the code unnecessarily verbose if the Symbol always gets initialized before use, this alleviates that as well by providing an `unsafe` way to get a temporary `Symbol`.

Ideally, `new_uninit` would be a trait method, but traits don't support const fns so I implemented it only for crate owned structs and the user can do so as well for their own types if they need it.