### PR TITLE
Prepare `v0.15.0` release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "string-interner"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Robbepop"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 0.15.0 - 2024/02/08
+
+## Changed
+
+- Update to `hashbrown` version `0.14.0`. (https://github.com/Robbepop/string-interner/pull/58)
+- Improve `no_std` support. (https://github.com/Robbepop/string-interner/pull/44)
+- Fix bug in `BufferBackend::with_capacity` method. (https://github.com/Robbepop/string-interner/pull/54)
+
 ## 0.14.0 - 2021/10/27
 
 ## Added


### PR DESCRIPTION
Closes https://github.com/Robbepop/string-interner/issues/62.