### PR TITLE
Improve varlen encoding of `BufferBackend`

### DIFF
--- a/src/backend/buffer.rs
+++ b/src/backend/buffer.rs
@@ -471,9 +471,9 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         self.backend
             .resolve_index_to_str(self.next)
-            .and_then(|(string, next_string_index)| {
+            .and_then(|(string, next)| {
                 let symbol = S::try_from_usize(self.next)?;
-                self.next = next_string_index;
+                self.next = next;
                 self.remaining -= 1;
                 Some((symbol, string))
             })

--- a/src/backend/buffer.rs
+++ b/src/backend/buffer.rs
@@ -86,7 +86,6 @@ where
     ///
     /// Returns the string from the given index if any as well
     /// as the index of the next string in the buffer.
-    #[inline]
     fn resolve_index_to_str(&self, index: usize) -> Option<(&str, usize)> {
         let bytes = self.buffer.get(index..)?;
         let (str_len, str_len_bytes) = decode_var_usize(bytes)?;
@@ -108,7 +107,6 @@ where
     ///
     /// The caller of the function has to ensure that calling this method
     /// is safe to do.
-    #[inline]
     unsafe fn resolve_index_to_str_unchecked(&self, index: usize) -> &str {
         // SAFETY: The function is marked unsafe so that the caller guarantees
         //         that required invariants are checked.
@@ -139,7 +137,6 @@ where
     /// # Panics
     ///
     /// If the backend ran out of symbols.
-    #[inline]
     fn push_string(&mut self, string: &str) -> S {
         let symbol = self.next_symbol();
         let str_len = string.len();

--- a/src/backend/buffer.rs
+++ b/src/backend/buffer.rs
@@ -110,15 +110,15 @@ where
     unsafe fn resolve_index_to_str_unchecked(&self, index: usize) -> &str {
         // SAFETY: The function is marked unsafe so that the caller guarantees
         //         that required invariants are checked.
-        let slice_len = unsafe { self.buffer.get_unchecked(index..) };
+        let bytes = unsafe { self.buffer.get_unchecked(index..) };
         // SAFETY: The function is marked unsafe so that the caller guarantees
         //         that required invariants are checked.
-        let (str_len, str_len_bytes) = unsafe { decode_var_usize_unchecked(slice_len) };
-        let start_str = index + str_len_bytes;
+        let (str_len, str_len_bytes) = unsafe { decode_var_usize_unchecked(bytes) };
+        let index_str = index + str_len_bytes;
         let str_bytes =
             // SAFETY: The function is marked unsafe so that the caller guarantees
             //         that required invariants are checked.
-            unsafe { self.buffer.get_unchecked(start_str..start_str + str_len) };
+            unsafe { self.buffer.get_unchecked(index_str..index_str + str_len) };
         // SAFETY: It is guaranteed by the backend that only valid strings
         //         are stored in this portion of the buffer.
         unsafe { str::from_utf8_unchecked(str_bytes) }

--- a/src/backend/buffer.rs
+++ b/src/backend/buffer.rs
@@ -86,6 +86,7 @@ where
     ///
     /// Returns the string from the given index if any as well
     /// as the index of the next string in the buffer.
+    #[inline]
     fn resolve_index_to_str(&self, index: usize) -> Option<(&str, usize)> {
         let bytes = self.buffer.get(index..)?;
         let (str_len, str_len_bytes) = decode_var_usize(bytes)?;
@@ -107,6 +108,7 @@ where
     ///
     /// The caller of the function has to ensure that calling this method
     /// is safe to do.
+    #[inline]
     unsafe fn resolve_index_to_str_unchecked(&self, index: usize) -> &str {
         // SAFETY: The function is marked unsafe so that the caller guarantees
         //         that required invariants are checked.
@@ -137,6 +139,7 @@ where
     /// # Panics
     ///
     /// If the backend ran out of symbols.
+    #[inline]
     fn push_string(&mut self, string: &str) -> S {
         let symbol = self.next_symbol();
         let str_len = string.len();


### PR DESCRIPTION
Unlike https://github.com/Robbepop/string-interner/pull/51/ this does not change the encoding of string lengths however it further improves the common cases of strings with `string.len <= 254` with simply `#[inline]` and `#[cold]` attributes mostly.
Benchmarks show significant improvements for `resolve` and `iter`:

![image](https://github.com/Robbepop/string-interner/assets/8193155/2737aaa8-d083-4b1b-8b3a-43368c5b45c6)

![image](https://github.com/Robbepop/string-interner/assets/8193155/b897aa84-adfd-4aec-af99-9118c42f634b)
