### PR TITLE
Fix unsoundness in `BucketBackend::shrink_to_fit`

### DIFF
--- a/src/backend/bucket/fixed_str.rs
+++ b/src/backend/bucket/fixed_str.rs
@@ -56,9 +56,4 @@ impl FixedString {
             },
         ))
     }
-
-    /// Shrink capacity to fit the contents exactly.
-    pub fn shrink_to_fit(&mut self) {
-        self.contents.shrink_to_fit();
-    }
 }

--- a/src/backend/bucket/mod.rs
+++ b/src/backend/bucket/mod.rs
@@ -114,7 +114,8 @@ where
 
     fn shrink_to_fit(&mut self) {
         self.spans.shrink_to_fit();
-        self.head.shrink_to_fit();
+        // Commenting out the below line fixes: https://github.com/Robbepop/string-interner/issues/46
+        // self.head.shrink_to_fit();
         self.full.shrink_to_fit();
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -34,10 +34,10 @@ pub trait BackendStats {
 }
 
 impl BackendStats for backend::BucketBackend<DefaultSymbol> {
-    const MIN_OVERHEAD: f64 = 2.1;
-    const MAX_OVERHEAD: f64 = 2.33;
-    const MAX_ALLOCATIONS: usize = 66;
-    const MAX_DEALLOCATIONS: usize = 43;
+    const MIN_OVERHEAD: f64 = 2.2;
+    const MAX_OVERHEAD: f64 = 3.1;
+    const MAX_ALLOCATIONS: usize = 65;
+    const MAX_DEALLOCATIONS: usize = 42;
     const NAME: &'static str = "BucketBackend";
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -360,6 +360,34 @@ macro_rules! gen_tests_for_backend {
             let expected_iter = symbols.into_iter().zip(strings);
             assert!(Iterator::eq(expected_iter, &interner));
         }
+
+        #[test]
+        fn shrink_to_fit_works() {
+            let mut interner = StringInterner::new();
+            // Insert 3 unique strings:
+            let aa = interner.get_or_intern("aa").to_usize();
+            let bb = interner.get_or_intern("bb").to_usize();
+            let cc = interner.get_or_intern("cc").to_usize();
+
+            interner.shrink_to_fit();
+
+            assert_eq!(
+                interner.get_or_intern("aa").to_usize(),
+                aa,
+                "'aa' did not produce the same symbol",
+            );
+            assert_eq!(
+                interner.get_or_intern("bb").to_usize(),
+                bb,
+                "'bb' did not produce the same symbol",
+            );
+            assert_eq!(
+                interner.get_or_intern("cc").to_usize(),
+                cc,
+                "'cc' did not produce the same symbol",
+            );
+            assert_eq!(interner.len(), 3);
+        }
     };
 }
 


### PR DESCRIPTION
Closes https://github.com/Robbepop/string-interner/issues/46.