### PR TITLE
Fix `BufferBackend` soundness issue and add `StringInterner::resolve_unchecked`

### DIFF
--- a/src/interner.rs
+++ b/src/interner.rs
@@ -264,10 +264,21 @@ where
         self.backend.shrink_to_fit()
     }
 
-    /// Returns the string for the given symbol if any.
+    /// Returns the string for the given `symbol`` if any.
     #[inline]
     pub fn resolve(&self, symbol: <B as Backend>::Symbol) -> Option<&str> {
         self.backend.resolve(symbol)
+    }
+
+    /// Returns the string for the given `symbol` without performing any checks.
+    ///
+    /// # Safety
+    ///
+    /// It is the caller's responsibility to provide this method with `symbol`s
+    /// that are valid for the [`StringInterner`].
+    #[inline]
+    pub unsafe fn resolve_unchecked(&self, symbol: <B as Backend>::Symbol) -> &str {
+        unsafe { self.backend.resolve_unchecked(symbol) }
     }
 
     /// Returns an iterator that yields all interned strings and their symbols.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -299,6 +299,26 @@ macro_rules! gen_tests_for_backend {
         }
 
         #[test]
+        fn resolve_unchecked_works() {
+            let mut interner = StringInterner::new();
+            // Insert 3 unique strings:
+            let aa = interner.get_or_intern("aa");
+            let bb = interner.get_or_intern("bb");
+            let cc = interner.get_or_intern("cc");
+            assert_eq!(interner.len(), 3);
+            // Resolve valid symbols:
+            assert_eq!(unsafe { interner.resolve_unchecked(aa) }, "aa");
+            assert_eq!(unsafe { interner.resolve_unchecked(bb) }, "bb");
+            assert_eq!(unsafe { interner.resolve_unchecked(cc) }, "cc");
+            assert_eq!(interner.len(), 3);
+            // Resolve invalid symbols:
+            let dd = expect_valid_symbol(1000);
+            assert_ne!(aa, dd);
+            assert_ne!(bb, dd);
+            assert_ne!(cc, dd);
+        }
+
+        #[test]
         fn get_works() {
             let mut interner = StringInterner::new();
             // Insert 3 unique strings:


### PR DESCRIPTION
Closes https://github.com/Robbepop/string-interner/issues/49.

This fix vastly deteriorates the performance of `BufferBackend::resolve` which is why I added `StringInterner::resolve_unchecked` for users to mitigate the performance issue on their side if they are sure to always use valid symbols.
Even with the regressed performance for `resolve` the `BufferBackend` is _the choice_ for especially memory constrained environments.

Benchmarks:

```
resolve/already-filled/BucketBackend
                        time:   [61.173 µs 61.271 µs 61.368 µs]
                        thrpt:  [1.6295 Gelem/s 1.6321 Gelem/s 1.6347 Gelem/s]

resolve/already-filled/StringBackend
                        time:   [78.175 µs 78.260 µs 78.359 µs]
                        thrpt:  [1.2762 Gelem/s 1.2778 Gelem/s 1.2792 Gelem/s]

resolve/already-filled/BufferBackend
                        time:   [448.82 µs 449.71 µs 450.60 µs]
                        thrpt:  [221.93 Melem/s 222.37 Melem/s 222.81 Melem/s]

resolve_unchecked/already-filled/BucketBackend
                        time:   [59.920 µs 59.999 µs 60.081 µs]
                        thrpt:  [1.6644 Gelem/s 1.6667 Gelem/s 1.6689 Gelem/s]

resolve_unchecked/already-filled/StringBackend
                        time:   [72.390 µs 72.483 µs 72.589 µs]
                        thrpt:  [1.3776 Gelem/s 1.3796 Gelem/s 1.3814 Gelem/s]

resolve_unchecked/already-filled/BufferBackend
                        time:   [58.920 µs 58.995 µs 59.078 µs]
                        thrpt:  [1.6927 Gelem/s 1.6950 Gelem/s 1.6972 Gelem/s]
```