### PR TITLE
Implement Default on interners for all backends

### DIFF
--- a/src/interner.rs
+++ b/src/interner.rs
@@ -51,8 +51,7 @@ where
     }
 }
 
-#[cfg(feature = "backends")]
-impl Default for StringInterner<crate::DefaultBackend> {
+impl<B: Backend, H: BuildHasher + Default> Default for StringInterner<B, H> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn default() -> Self {
         StringInterner::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,9 @@
 //! ### Example: Interning & Symbols
 //!
 //! ```
-//! use string_interner::StringInterner;
+//! use string_interner::{DefaultBackend, StringInterner};
 //!
-//! let mut interner = StringInterner::default();
+//! let mut interner = StringInterner::<DefaultBackend>::default();
 //! let sym0 = interner.get_or_intern("Elephant");
 //! let sym1 = interner.get_or_intern("Tiger");
 //! let sym2 = interner.get_or_intern("Horse");
@@ -33,8 +33,8 @@
 //! ### Example: Look-up
 //!
 //! ```
-//! # use string_interner::StringInterner;
-//! let mut interner = StringInterner::default();
+//! # use string_interner::{DefaultBackend, StringInterner};
+//! let mut interner = StringInterner::<DefaultBackend>::default();
 //! let sym = interner.get_or_intern("Banana");
 //! assert_eq!(interner.resolve(sym), Some("Banana"));
 //! ```


### PR DESCRIPTION
It’s useful to have `Default` implemented for `StringInterner` for all backends, not just `DefaultBackend`, so that structs containing such interners can `derive(Default)` rather than having to implement it by hand. However, as can be seen in the changes to the doctests, this is not actually backwards compatible, because `StringInterner::default()` now requires types to be provided, so you may or may not consider it worth a semver break; feel free to just close this if you don’t want to do that, I don’t mind.