### PR TITLE
Fix off-by-one bug in serde impl for Symbol types

### DIFF
--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -93,7 +93,7 @@ macro_rules! impl_serde_for_symbol {
                 &self,
                 serializer: T,
             ) -> ::core::result::Result<T::Ok, T::Error> {
-                self.value.serialize(serializer)
+                self.to_usize().serialize(serializer)
             }
         }
 
@@ -119,3 +119,74 @@ macro_rules! impl_serde_for_symbol {
 impl_serde_for_symbol!(SymbolU16, u16);
 impl_serde_for_symbol!(SymbolU32, u32);
 impl_serde_for_symbol!(SymbolUsize, usize);
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        symbol::{SymbolU16, SymbolU32, SymbolUsize},
+        Symbol,
+    };
+    use serde_json;
+
+    fn symbol_round_trip_serializes<S>(symbol: S) -> bool
+    where
+        S: Symbol + std::fmt::Debug + serde::Serialize + serde::de::DeserializeOwned + PartialEq,
+    {
+        let serialized = serde_json::to_string(&symbol).expect("serialization should succeed");
+        let deserialized: S =
+            serde_json::from_str(&serialized).expect("deserialization should succeed");
+        symbol == deserialized
+    }
+
+    #[test]
+    fn symbol_u16_round_trips() {
+        assert!(symbol_round_trip_serializes(
+            SymbolU16::try_from_usize(0).unwrap()
+        ));
+        assert!(symbol_round_trip_serializes(
+            SymbolU16::try_from_usize(42).unwrap()
+        ));
+        assert!(symbol_round_trip_serializes(
+            SymbolU16::try_from_usize(u16::MAX as usize - 1).unwrap()
+        ));
+    }
+
+    #[test]
+    fn symbol_u32_round_trips() {
+        assert!(symbol_round_trip_serializes(
+            SymbolU32::try_from_usize(0).unwrap()
+        ));
+        assert!(symbol_round_trip_serializes(
+            SymbolU32::try_from_usize(42).unwrap()
+        ));
+        assert!(symbol_round_trip_serializes(
+            SymbolU32::try_from_usize(u32::MAX as usize - 1).unwrap()
+        ));
+    }
+
+    #[test]
+    fn symbol_usize_round_trips() {
+        assert!(symbol_round_trip_serializes(
+            SymbolUsize::try_from_usize(0).unwrap()
+        ));
+        assert!(symbol_round_trip_serializes(
+            SymbolUsize::try_from_usize(42).unwrap()
+        ));
+        assert!(symbol_round_trip_serializes(
+            SymbolUsize::try_from_usize(usize::MAX as usize - 1).unwrap()
+        ));
+    }
+
+    #[test]
+    fn raw_usize_round_trips() {
+        assert!(symbol_round_trip_serializes(
+            usize::try_from_usize(0).unwrap()
+        ));
+        assert!(symbol_round_trip_serializes(
+            usize::try_from_usize(42).unwrap()
+        ));
+        assert!(symbol_round_trip_serializes(
+            usize::try_from_usize(usize::MAX).unwrap()
+        ));
+    }
+}


### PR DESCRIPTION
The various Symbols' serde implementations had a bug that would cause their underlying index to increase by 1 each time they're serialized and deserialized, because the serialize impl didn't account for the fact that `Symbol::new()` adds one to guarantee that the resulting index is non-zero.

This fixes that and adds tests for it.

* A less obtuse fix would be to move the `+ 1` operation out of `Symbol::new()` and into the deserialize impl for each Symbol, but I'm not sure if something else in this codebase relies on `Symbol::new()` adding 1.
* Wasn't sure whether you want tests in serde_impl.rs or in the existing integration test binary; I opted for the former because it means the tests will neatly be automatically disabled if the serde feature is off.

---

Fixes #88 .